### PR TITLE
Clean up confs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ the PlasmaPy project.  The primary URL will hopefully
 soon be:
 [`https://www.plasmapy.org/`](https://www.plasmapy.org/)
 
+## Building the website
+
+1. Clone the repository.
+2. Install nikola (using `pip` for example).
+3. Go to `src` branch.
+4. Update data from [`PlasmaPy repository`](https://github.com/PlasmaPy/PlasmaPy) using `pull_from_github.py`.
+5. Build the website:
+    - Inside `web/` directory run `nikola build`
+    - Preview the changes with `nikola serve --browser`
+    - Deploy to github pages with `nikola github_deploy`
+
 ## License
 
 See [LICENSE.md](./LICENSE.md) for this repository's license.

--- a/pull_from_github.py
+++ b/pull_from_github.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import requests as re
 
 OUTPUT_DIR = "web/pages/"
@@ -10,6 +11,10 @@ PAGES = {
     "contribute":{
         "filename": OUTPUT_DIR + "contribute.md",
         "url": BASE_URL + "CONTRIBUTING.md"
+    },
+    "license":{
+        "filename": OUTPUT_DIR + "license.md",
+        "url": BASE_URL + "LICENSE.md"
     }
 }
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -931,15 +931,14 @@ FEED_LINKS_APPEND_QUERY = False
 LICENSE = ""
 # I recommend using the Creative Commons' wizard:
 # https://creativecommons.org/choose/
-# LICENSE = """
-# <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-# <img alt="Creative Commons License BY-NC-SA"
-# style="border-width:0; margin-bottom:12px;"
-# src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"></a>"""
+LICENSE = """
+<a href="/license">
+License
+</a>"""
 
 # A small copyright notice for the page footer (in HTML).
 # (translatable)
-CONTENT_FOOTER = 'Contents &copy; {date}         <a href="{repo}">{author}</a> - Powered by         <a href="https://getnikola.com" rel="nofollow">Nikola</a>         {license}'
+CONTENT_FOOTER = 'Contents &copy; {date}         <a href="{repo}">{author}</a> - {license} - Powered by         <a href="https://getnikola.com" rel="nofollow">Nikola</a>'
 
 # Things that will be passed to CONTENT_FOOTER.format().  This is done
 # for translatability, as dicts are not formattable.  Nikola will

--- a/web/conf.py
+++ b/web/conf.py
@@ -24,8 +24,8 @@ BLOG_TITLE = "PlasmaPy"  # (translatable)
 SITE_URL = "https://plasmapy.github.io/"
 # This is the URL where Nikola's output will be deployed.
 # If not set, defaults to SITE_URL
-# BASE_URL = "https://robertnf.github.io/"
-#BLOG_EMAIL = "r.r.1994a@gmail.com"
+BASE_URL = "https://plasmapy.github.io/"
+PROJECT_REPOSITORY = "https://github.com/PlasmaPy/PlasmaPy"
 BLOG_DESCRIPTION = "Webpage for PlasmaPy."  # (translatable)
 
 # Nikola is multilingual!
@@ -939,7 +939,7 @@ LICENSE = ""
 
 # A small copyright notice for the page footer (in HTML).
 # (translatable)
-CONTENT_FOOTER = 'Contents &copy; {date}         <a href="mailto:{email}">{author}</a> - Powered by         <a href="https://getnikola.com" rel="nofollow">Nikola</a>         {license}'
+CONTENT_FOOTER = 'Contents &copy; {date}         <a href="{repo}">{author}</a> - Powered by         <a href="https://getnikola.com" rel="nofollow">Nikola</a>         {license}'
 
 # Things that will be passed to CONTENT_FOOTER.format().  This is done
 # for translatability, as dicts are not formattable.  Nikola will
@@ -958,7 +958,7 @@ CONTENT_FOOTER_FORMATS = {
     DEFAULT_LANG: (
         (),
         {
-            "email": BLOG_EMAIL,
+            "repo": PROJECT_REPOSITORY,
             "author": BLOG_AUTHOR,
             "date": time.gmtime().tm_year,
             "license": LICENSE
@@ -968,7 +968,7 @@ CONTENT_FOOTER_FORMATS = {
 
 # A simple copyright tag for inclusion in RSS feeds that works just
 # like CONTENT_FOOTER and CONTENT_FOOTER_FORMATS
-RSS_COPYRIGHT = 'Contents © {date} <a href="mailto:{email}">{author}</a> {license}'
+RSS_COPYRIGHT = 'Contents © {date} <a href={repo}>{author}</a> {license}'
 RSS_COPYRIGHT_PLAIN = 'Contents © {date} {author} {license}'
 RSS_COPYRIGHT_FORMATS = CONTENT_FOOTER_FORMATS
 

--- a/web/pages/index.html
+++ b/web/pages/index.html
@@ -1,12 +1,10 @@
 <html>
     <head>
         <title>PlasmaPy</title>
-        <meta name="tags" content="thats, awesome" />
+        <meta name="tags" content="PlasmaPy, physics, python, astroPy" />
         <meta name="date" content="2012-07-09 22:28" />
-        <meta name="modified" content="2012-07-10 20:14" />
-        <meta name="category" content="yeah" />
-        <meta name="authors" content="Conan Doyle" />
-        <meta name="summary" content="Short version for index and feeds" />
+        <meta name="authors" content="PlasmaPy Developers" />
+        <meta name="summary" content="Main page for the PlasmaPy community" />
     </head>
     <body>
         <div id="description">

--- a/web/pages/license.md
+++ b/web/pages/license.md
@@ -1,0 +1,26 @@
+Copyright (c) 2015-2017, PlasmaPy Community. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of PlasmaPy nor the names of its contributors may be used 
+  to endorse or promote products derived from this software without specific 
+  prior written permission.
+
+This software is provided by the copyright holders and contributors "as is"
+and any express or implied warranties, including, but not limited to, the 
+implied warranties of merchantability and fitness for a particular purpose are 
+disclaimed. In no event shall the copyright holder or contributors be liable
+for any direct, indirect, incidental, special, exemplary, or consequential
+damages (including, but not limited to, procurement of substitute goods or
+services; loss of use, data, or profits; or business interruption) however
+caused and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of the use
+of this software, even if advised of the possibility of such damage.


### PR DESCRIPTION
Changes:

- Cleaned up config.py from any mentions to me, generalized to PlasmaPy developers.
- Added License to webpage footer, autogenerated from https://github.com/PlasmaPy/plasmapy.github.io/blob/master/LICENSE.md using `pull_from_github.py`
- Added instructions on how to build the website to `README.md` (Note that the first time the web is built there's no need to go to the `src` branch, as it will be created automatically by `nikola github_deploy`).
- Changed tags and demo information from` index.html`.