### PR TITLE
Let Travis CI set 'CNAME' when deploying on Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ deploy:
     branch: src
   local_dir: web/output
   github_token: $GITHUB_TOKEN
+  fqdn: plasmapy.org
 notifications:
   email:
     on_success: change

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-plasmapy.org


### PR DESCRIPTION
Travis CI is able to create the 'CNAME' file when deploying on GitHub
Pages automatically.

GitHub-Issue: #8
GitHub-Issue: #5