### PR TITLE
Create landing page, reorganize website, and add funding acknowledgment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ cache/
 output/
 id_rsa
 id_rsa.pub
+.idea
 __pycache__
 web/.doit.db.bak
 web/.doit.db.dat
+web/.doit.db.db
 web/.doit.db.dir

--- a/web/conf.py
+++ b/web/conf.py
@@ -145,34 +145,56 @@ TRANSLATIONS_PATTERN = "{path}.{lang}.{ext}"
 
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
+
         ((
             ("/about", "About PlasmaPy"),
             ("/news", "News"),
+            (PROJECT_REPOSITORY, "Repository"),
             ("/acknowledging", "Acknowledging"),
             ("/conduct", "Code of Conduct")
         ), "About"),
+
         (DOCS, "Documentation"),
-        (
-            (
+
+        ((
                 (RIOT, "Chat room"),
+                ("https://plasmapy.discourse.group/", "Discussion forum"),
                 (MAILING_LIST, "Email list"),
                 (FEEDBACK_BOX, "Suggestion box"),
-                (TWITTER, "Twitter"),
+
+        ), "Contact"),
+        ((
 #                (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
                 (TELECON_CALENDAR, "Calendar"),
-                ("https://plasmapy.discourse.group/", "Discussion forum"),
+                (TWITTER, "Twitter"),
 #                (TELECON_NOTES, "Notes from weekly meetups"),
+                ((
+                    (RITIEK, "GSoC 2018"),
+                ), "GSoC"),
+
         ), "Community"),
+
         ("/contribute", "Contribute"),
-        (PROJECT_REPOSITORY, "Repository"),
+
         # ("/quickstart", "Quickstart guide"),
         # ("/team", "Team"),
-        ((
-            (RITIEK, "GSoC 2018"),
-        ), "GSoC"),
+
         (BENCHMARKS, "Benchmarks"),
+
     )
 }
+
+# put GSoC into community
+# put repository into the About mention as GitHub Repository
+
+
+# Contact  how they talk to us
+#   - chat room, email, suggestion box, discussion forum
+
+# Community  how we reach to the community
+#   - Twitter, cal, Meetings, GSoC  # in future, education
+
+# Make a Meetings page menu, with the Bryn Mawr meeting as a subitem
 
 # Name of the theme to use.
 THEME = "bootstrap4"

--- a/web/conf.py
+++ b/web/conf.py
@@ -36,7 +36,9 @@ RITIEK = "https://ritiek.github.io/posts/"
 FEEDBACK_BOX = "https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link"
 TELECON_CALENDAR = "https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
 TELECON_LINK = "https://jitsi.riot.im/plasmapy"
-TELECON_NOTES = "https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing"
+TELECON_NOTES = (
+    "https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing"
+)
 BENCHMARKS = "http://www.plasmapy.org/plasmapy-benchmarks/"
 
 # Nikola is multilingual!
@@ -145,42 +147,40 @@ TRANSLATIONS_PATTERN = "{path}.{lang}.{ext}"
 
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
-
-        ((
-            ("/about", "About PlasmaPy"),
-            ("/news", "News"),
-            (PROJECT_REPOSITORY, "Repository"),
-            ("/acknowledging", "Acknowledging"),
-            ("/conduct", "Code of Conduct")
-        ), "About"),
-
+        (
+            (
+                ("/about", "About PlasmaPy"),
+                ("/news", "News"),
+                (PROJECT_REPOSITORY, "Repository"),
+                ("/acknowledging", "Acknowledging"),
+                ("/conduct", "Code of Conduct"),
+            ),
+            "About",
+        ),
         (DOCS, "Documentation"),
-
-        ((
+        (
+            (
                 (RIOT, "Chat room"),
                 ("https://plasmapy.discourse.group/", "Discussion forum"),
                 (MAILING_LIST, "Email list"),
                 (FEEDBACK_BOX, "Suggestion box"),
-
-        ), "Contact"),
-        ((
-#                (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
+            ),
+            "Contact",
+        ),
+        (
+            (
+                # (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
                 (TELECON_CALENDAR, "Calendar"),
                 (TWITTER, "Twitter"),
-#                (TELECON_NOTES, "Notes from weekly meetups"),
-                ((
-                    (RITIEK, "GSoC 2018"),
-                ), "GSoC"),
-
-        ), "Community"),
-
+                # (TELECON_NOTES, "Notes from weekly meetups"),
+                (((RITIEK, "GSoC 2018"),), "GSoC"),
+            ),
+            "Community",
+        ),
         ("/contribute", "Contribute"),
-
         # ("/quickstart", "Quickstart guide"),
         # ("/team", "Team"),
-
         (BENCHMARKS, "Benchmarks"),
-
     )
 }
 
@@ -189,7 +189,7 @@ THEME = "bootstrap4"
 
 # Primary color of your theme. This will be used to customize your theme and
 # auto-generate related colors in POSTS_SECTION_COLORS. Must be a HEX value.
-THEME_COLOR = '#5670d4'
+THEME_COLOR = "#5670d4"
 
 # POSTS and PAGES contains (wildcard, destination, template) tuples.
 # (translatable)
@@ -225,9 +225,7 @@ THEME_COLOR = '#5670d4'
 #         ("pages/*.md", {"en": "pages", "de": "seiten"}, "page.tmpl"),
 #     )
 
-POSTS = (
-    ("posts/*.rst", "posts", "post.tmpl"),
-)
+POSTS = (("posts/*.rst", "posts", "post.tmpl"),)
 PAGES = (
     ("pages/*.rst", "", "story.tmpl"),
     ("pages/*.txt", "", "story.tmpl"),
@@ -304,18 +302,18 @@ TIMEZONE = "UTC+2"
 # 'markdown' is Markdown
 # 'html' assumes the file is HTML and just copies it
 COMPILERS = {
-    "rest": ('.rst', '.txt'),
-    "markdown": ('.md', '.mdown', '.markdown'),
-    "textile": ('.textile',),
-    "txt2tags": ('.t2t',),
-    "bbcode": ('.bb',),
-    "wiki": ('.wiki',),
-    "ipynb": ('.ipynb',),
-    "html": ('.html', '.htm'),
+    "rest": (".rst", ".txt"),
+    "markdown": (".md", ".mdown", ".markdown"),
+    "textile": (".textile",),
+    "txt2tags": (".t2t",),
+    "bbcode": (".bb",),
+    "wiki": (".wiki",),
+    "ipynb": (".ipynb",),
+    "html": (".html", ".htm"),
     # PHP files are rendered the usual way (i.e. with the full templates).
     # The resulting files have .php extensions, making it possible to run
     # them without reconfiguring your server to recognize them.
-    "php": ('.php',),
+    "php": (".php",),
     # Pandoc detects the input from the source filename
     # but is disabled by default as it would conflict
     # with many of the others.
@@ -352,7 +350,7 @@ COMPILERS = {
 # Nikola supports logo display.  If you have one, you can put the URL here.
 # Final output is <img src="LOGO_URL" id="logo" alt="BLOG_TITLE">.
 # The URL may be relative to the site root.
-LOGO_URL = '/images/with-text-light-small.png'
+LOGO_URL = "/images/with-text-light-small.png"
 
 # If you want to hide the title of your website (for example, if your logo
 # already contains the text), set this to False.
@@ -475,7 +473,7 @@ POSTS_SECTIONS = True
 # If you do not want to display a tag publicly, you can mark it as hidden.
 # The tag will not be displayed on the tag list page, the tag cloud and posts.
 # Tag pages will still be generated.
-HIDDEN_TAGS = ['mathjax']
+HIDDEN_TAGS = ["mathjax"]
 
 # Only include tags on the tag list/overview page if there are at least
 # TAGLIST_MINIMUM_POSTS number of posts or more with every tag. Every tag
@@ -585,7 +583,7 @@ HIDDEN_CATEGORIES = []
 # If you do not want to display an author publicly, you can mark it as hidden.
 # The author will not be displayed on the author list page and posts.
 # Tag pages will still be generated.
-HIDDEN_AUTHORS = ['Guest']
+HIDDEN_AUTHORS = ["Guest"]
 
 # Final location for the main blog page and sibling paginated pages is
 # output / TRANSLATION[lang] / INDEX_PATH / index-*.html
@@ -594,9 +592,7 @@ INDEX_PATH = "news/"
 
 # Optional HTML that displayed on “main” blog index.html files.
 # May be used for a greeting. (translatable)
-FRONT_INDEX_HEADER = {
-    DEFAULT_LANG: ''
-}
+FRONT_INDEX_HEADER = {DEFAULT_LANG: ""}
 
 # Create per-month archives instead of per-year
 # CREATE_MONTHLY_ARCHIVE = False
@@ -680,11 +676,11 @@ REDIRECTIONS = []
 # For more details, read the manual:
 # https://getnikola.com/handbook.html#deploying-to-github
 # You will need to configure the deployment branch on GitHub.
-GITHUB_SOURCE_BRANCH = 'src'
-GITHUB_DEPLOY_BRANCH = 'master'
+GITHUB_SOURCE_BRANCH = "src"
+GITHUB_DEPLOY_BRANCH = "master"
 
 # The name of the remote where you wish to push to, using github_deploy.
-GITHUB_REMOTE_NAME = 'origin'
+GITHUB_REMOTE_NAME = "origin"
 
 # Whether or not github_deploy should commit to the source branch automatically
 # before deploying.
@@ -859,7 +855,7 @@ GITHUB_COMMIT_SOURCE = False
 # (the thumbnail has ``.thumbnail`` added before the file extension by default,
 # but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
 
-IMAGE_FOLDERS = {'images': 'images'}
+IMAGE_FOLDERS = {"images": "images"}
 # IMAGE_THUMBNAIL_SIZE = 400
 # IMAGE_THUMBNAIL_FORMAT = '{name}.thumbnail{ext}'
 
@@ -1006,14 +1002,14 @@ CONTENT_FOOTER_FORMATS = {
             "license": LICENSE,
             "twitter": TWITTER,
             "riot": RIOT,
-        }
+        },
     )
 }
 
 # A simple copyright tag for inclusion in RSS feeds that works just
 # like CONTENT_FOOTER and CONTENT_FOOTER_FORMATS
-RSS_COPYRIGHT = 'Contents © {date} <a href={repo}>{author}</a> {license}'
-RSS_COPYRIGHT_PLAIN = 'Contents © {date} {author} {license}'
+RSS_COPYRIGHT = "Contents © {date} <a href={repo}>{author}</a> {license}"
+RSS_COPYRIGHT_PLAIN = "Contents © {date} {author} {license}"
 RSS_COPYRIGHT_FORMATS = CONTENT_FOOTER_FORMATS
 
 # To use comments, you can choose between different third party comment
@@ -1142,8 +1138,12 @@ PRETTY_URLS = True
 # Note: most Nikola-specific extensions are done via the Nikola plugin system,
 #       with the MarkdownExtension class and should not be added here.
 # The default is ['fenced_code', 'codehilite']
-MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.codehilite', 'markdown.extensions.extra',
-'markdown.extensions.meta']
+MARKDOWN_EXTENSIONS = [
+    "markdown.extensions.fenced_code",
+    "markdown.extensions.codehilite",
+    "markdown.extensions.extra",
+    "markdown.extensions.meta",
+]
 
 # Extra options to pass to the pandoc command.
 # by default, it's empty, is a list of strings, for example

--- a/web/conf.py
+++ b/web/conf.py
@@ -35,7 +35,7 @@ MAILING_LIST = "https://groups.google.com/forum/#!forum/plasmapy"
 RITIEK = "https://ritiek.github.io/posts/"
 FEEDBACK_BOX = "https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform?usp=sf_link"
 TELECON_CALENDAR = "https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
-TELECON_LINK = "https://meet.jit.si/plasmapy"
+TELECON_LINK = "https://jitsi.riot.im/plasmapy"
 TELECON_NOTES = "https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing"
 BENCHMARKS = "http://www.plasmapy.org/plasmapy-benchmarks/"
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -582,7 +582,7 @@ HIDDEN_AUTHORS = ['Guest']
 # Final location for the main blog page and sibling paginated pages is
 # output / TRANSLATION[lang] / INDEX_PATH / index-*.html
 # (translatable)
-INDEX_PATH = ""
+INDEX_PATH = "news/"
 
 # Optional HTML that displayed on “main” blog index.html files.
 # May be used for a greeting. (translatable)

--- a/web/conf.py
+++ b/web/conf.py
@@ -160,6 +160,7 @@ NAVIGATION_LINKS = {
                 (TWITTER, "Twitter"),
 #                (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
                 (TELECON_CALENDAR, "Calendar"),
+                ("https://plasmapy.discourse.group/", "Discussion forum"),
 #                (TELECON_NOTES, "Notes from weekly meetups"),
         ), "Community"),
         ("/contribute", "Contribute"),

--- a/web/conf.py
+++ b/web/conf.py
@@ -145,7 +145,6 @@ TRANSLATIONS_PATTERN = "{path}.{lang}.{ext}"
 
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
-        (PROJECT_REPOSITORY, "GitHub"),
         ((
             ("/about", "About PlasmaPy"),
             ("/news", "News"),
@@ -153,26 +152,24 @@ NAVIGATION_LINKS = {
             ("/conduct", "Code of Conduct")
         ), "About"),
         (DOCS, "Documentation"),
-        (BENCHMARKS, "Benchmarks"),
-        # ("/quickstart", "Quickstart guide"),
-        ("/contribute", "Contribute"),
         (
             (
-                (RIOT, "Chat"),
-                (MAILING_LIST, "Mailing list"),
+                (RIOT, "Chat room"),
+                (MAILING_LIST, "Email list"),
                 (FEEDBACK_BOX, "Suggestion box"),
                 (TWITTER, "Twitter"),
-            ), "Contact"),
-        ((
-            (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
-            (TELECON_CALENDAR, "Teleconference calendar & dates"),
-            (TELECON_NOTES, "Notes from weekly meetups"),
-        ), "Teleconferences"),
+#                (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
+                (TELECON_CALENDAR, "Calendar"),
+#                (TELECON_NOTES, "Notes from weekly meetups"),
+        ), "Community"),
+        ("/contribute", "Contribute"),
+        (PROJECT_REPOSITORY, "Repository"),
+        # ("/quickstart", "Quickstart guide"),
         # ("/team", "Team"),
         ((
             (RITIEK, "GSoC 2018"),
         ), "GSoC"),
-
+        (BENCHMARKS, "Benchmarks"),
     )
 }
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -184,18 +184,6 @@ NAVIGATION_LINKS = {
     )
 }
 
-# put GSoC into community
-# put repository into the About mention as GitHub Repository
-
-
-# Contact  how they talk to us
-#   - chat room, email, suggestion box, discussion forum
-
-# Community  how we reach to the community
-#   - Twitter, cal, Meetings, GSoC  # in future, education
-
-# Make a Meetings page menu, with the Bryn Mawr meeting as a subitem
-
 # Name of the theme to use.
 THEME = "bootstrap4"
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -169,11 +169,11 @@ NAVIGATION_LINKS = {
         ),
         (
             (
-                # (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
+#                # (TELECON_LINK, "Teleconference room (Jitsi Meet)"),
                 (TELECON_CALENDAR, "Calendar"),
                 (TWITTER, "Twitter"),
-                # (TELECON_NOTES, "Notes from weekly meetups"),
-                (((RITIEK, "GSoC 2018"),), "GSoC"),
+#                # (TELECON_NOTES, "Notes from weekly meetups"),
+                (RITIEK, "GSoC 2018"),
             ),
             "Community",
         ),
@@ -362,7 +362,7 @@ WRITE_TAG_CLOUD = True
 
 # Generate pages for each section. The site must have at least two sections
 # for this option to take effect. It wouldn't build for just one section.
-POSTS_SECTIONS = True
+#POSTS_SECTIONS = True
 
 # Setting this to False generates a list page instead of an index. Indexes
 # are the default and will apply GENERATE_ATOM if set.
@@ -1313,7 +1313,7 @@ MARKDOWN_EXTENSIONS = [
 
 # If you hate "Filenames with Capital Letters and Spaces.md", you should
 # set this to true.
-UNSLUGIFY_TITLES = True
+FILE_METADATA_UNSLUGIFY_TITLES = True
 
 # Additional metadata that is added to a post when creating a new_post
 # ADDITIONAL_METADATA = {}

--- a/web/conf.py
+++ b/web/conf.py
@@ -148,7 +148,7 @@ NAVIGATION_LINKS = {
         (PROJECT_REPOSITORY, "GitHub"),
         ((
             ("/about", "About PlasmaPy"),
-            ("/", "PlasmaPy News"),
+            ("/news", "News"),
             ("/acknowledging", "Acknowledging"),
             ("/conduct", "Code of Conduct")
         ), "About"),

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -22,14 +22,7 @@ source software ecosystem for plasma research and education.
 ## Acknowledgments
 
 Ongoing development of PlasmaPy is supported by the U.S. National
-Science Foundation under grants 1931388, 1931393, 1931429, and
-1931435; NASA grant 80NSSC20K0174; and volunteers from the broader
-plasma physics community.  Early development of PlasmaPy was partially
-supported by grant DE-SC0016363 from the U.S. Department of Energy
-that was funded through the NSF-DOE Partnership on Basic Plasma
-Science and Engineering, a Scholarly Studies grant awarded by the
-Smithsonian Institution, and Google Summer of Code.  Any opinions,
-findings, and conclusions or recommendations expressed in this
-material are those of the authors and do not necessarily reflect the
-views of any of the funding agencies or organizations that have
-supported PlasmaPy development.
+Science Foundation and NASA, with many contributions from the broader
+plasma physics community.  Early development of PlasmaPy was supported
+by the U.S. Department of Energy, the Smithsonian Institution, and
+Google Summer of Code.

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -1,48 +1,34 @@
 title: The PlasmaPy Project
 
-The goal of the PlasmaPy Project is to foster the creation of an open source [Python](https://www.python.org/) ecosystem for plasma research and education.
+The goal of the PlasmaPy Project is to foster the creation of an open source [Python](https://www.python.org/) ecosystem for plasma research and education.  The PlasmaPy package contains core functionality for this software ecosystem, while affiliated packages will contain more specialized functionality.
 
 ## Install PlasmaPy
 
 PlasmaPy may be installed from the command line using [`pip`](https://pip.pypa.io/en/stable/):
 
-```
+```shell
 pip install plasmapy
 ```
 
 If you have a working installation of [conda](https://docs.conda.io/en/latest/), then you may install PlasmaPy with
 
-```
+```shell
 conda install -c conda-forge plasmapy
 ```
 
 ## Learn PlasmaPy
 
-[PlasmaPy's documentation](http://docs.plasmapy.org/en/latest) 
-describes how to use PlasmaPy and provides several 
-[examples](http://docs.plasmapy.org/en/latest/auto_examples/index.html). 
+[PlasmaPy's documentation](http://docs.plasmapy.org/en/latest) describes how to use PlasmaPy and provides several [examples](http://docs.plasmapy.org/en/latest/auto_examples/index.html). 
 
 ## Get Help
 
-The quickest way to reach PlasmaPy users and developers is through 
-[PlasmaPy's Riot chat room](https://riot.im/app/#/room/#plasmapy:openastronomy.org).  
-[PlasmaPy's Discourse group](https://plasmapy.discourse.group/) 
-is an ideal place for longer discussions on more detailed topics.
+The quickest way to reach PlasmaPy users and developers is through [PlasmaPy's Riot chat room](https://riot.im/app/#/room/#plasmapy:openastronomy.org).  [PlasmaPy's Discourse group](https://plasmapy.discourse.group/) is an ideal place for longer discussions on more detailed topics.
 
 ## Contribute and Report Bugs
 
-Making [feature requests](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Feature_request.md), 
-[reporting bugs](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Bug_report.md), 
-and [offering suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform) 
-are some of the most helpful ways to contribute to the ongoing development of PlasmaPy.
-
-The documentation discusses how to 
-[contribute code and documentation](http://docs.plasmapy.org/en/latest/CONTRIBUTING.html) 
-to PlasmaPy and contains a 
-[development guide](http://docs.plasmapy.org/en/latest/development/index.html).
+Making [feature requests](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Feature_request.md), [reporting bugs](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Bug_report.md), and [offering suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform) are some of the most helpful ways to contribute to the ongoing development of PlasmaPy.  The documentation discusses how to [contribute code and documentation](http://docs.plasmapy.org/en/latest/CONTRIBUTING.html) to PlasmaPy and contains a [development guide](http://docs.plasmapy.org/en/latest/development/index.html).
 
 ## Acknowledgments
 
-Ongoing development of PlasmaPy is supported by the U.S. National Science Foundation and NASA, with many contributions from the broader plasma physics and open source communities.  
-Early development of PlasmaPy was supported by the U.S. Department of Energy, the Smithsonian Institution, and Google Summer of Code.
+Ongoing development of PlasmaPy is supported by the U.S. National Science Foundation and NASA, with many contributions from the broader plasma physics and open source communities.  Early development of PlasmaPy was supported by the U.S. Department of Energy, the Smithsonian Institution, and Google Summer of Code.
 

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -1,0 +1,35 @@
+title: The PlasmaPy Project
+
+The goal of the PlasmaPy Project is to foster the creation of an open
+source software ecosystem for plasma research and education.
+
+## Install PlasmaPy
+
+...
+
+## Learn PlasmaPy
+
+...
+
+## Get Help
+
+...
+
+## Report bugs and contribute
+
+...
+
+## Acknowledgments
+
+Ongoing development of PlasmaPy is supported by the U.S. National
+Science Foundation under grants 1931388, 1931393, 1931429, and
+1931435; NASA grant 80NSSC20K0174; and volunteers from the broader
+plasma physics community.  Early development of PlasmaPy was partially
+supported by grant DE-SC0016363 from the U.S. Department of Energy
+that was funded through the NSF-DOE Partnership on Basic Plasma
+Science and Engineering, a Scholarly Studies grant awarded by the
+Smithsonian Institution, and Google Summer of Code.  Any opinions,
+findings, and conclusions or recommendations expressed in this
+material are those of the authors and do not necessarily reflect the
+views of any of the funding agencies or organizations that have
+supported PlasmaPy development.

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -1,28 +1,48 @@
 title: The PlasmaPy Project
 
-The goal of the PlasmaPy Project is to foster the creation of an open
-source software ecosystem for plasma research and education.
+The goal of the PlasmaPy Project is to foster the creation of an open source [Python](https://www.python.org/) ecosystem for plasma research and education.
 
 ## Install PlasmaPy
 
-...
+PlasmaPy may be installed from the command line using [`pip`](https://pip.pypa.io/en/stable/):
+
+```
+pip install plasmapy
+```
+
+If you have a working installation of [conda](https://docs.conda.io/en/latest/), then you may install PlasmaPy with
+
+```
+conda install -c conda-forge plasmapy
+```
 
 ## Learn PlasmaPy
 
-...
+[PlasmaPy's documentation](http://docs.plasmapy.org/en/latest) 
+describes how to use PlasmaPy and provides several 
+[examples](http://docs.plasmapy.org/en/latest/auto_examples/index.html). 
 
 ## Get Help
 
-...
+The quickest way to reach PlasmaPy users and developers is through 
+[PlasmaPy's Riot chat room](https://riot.im/app/#/room/#plasmapy:openastronomy.org).  
+[PlasmaPy's Discourse group](https://plasmapy.discourse.group/) 
+is an ideal place for longer discussions on more detailed topics.
 
-## Report bugs and contribute
+## Contribute and Report Bugs
 
-...
+Making [feature requests](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Feature_request.md), 
+[reporting bugs](https://github.com/PlasmaPy/PlasmaPy/issues/new?template=Bug_report.md), 
+and [offering suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdT3O5iHZrLJRuavFyzoR23PGy0Prfzx2SQOcwJGWtvHyT2lw/viewform) 
+are some of the most helpful ways to contribute to the ongoing development of PlasmaPy.
+
+The documentation discusses how to 
+[contribute code and documentation](http://docs.plasmapy.org/en/latest/CONTRIBUTING.html) 
+to PlasmaPy and contains a 
+[development guide](http://docs.plasmapy.org/en/latest/development/index.html).
 
 ## Acknowledgments
 
-Ongoing development of PlasmaPy is supported by the U.S. National
-Science Foundation and NASA, with many contributions from the broader
-plasma physics community.  Early development of PlasmaPy was supported
-by the U.S. Department of Energy, the Smithsonian Institution, and
-Google Summer of Code.
+Ongoing development of PlasmaPy is supported by the U.S. National Science Foundation and NASA, with many contributions from the broader plasma physics and open source communities.  
+Early development of PlasmaPy was supported by the U.S. Department of Energy, the Smithsonian Institution, and Google Summer of Code.
+

--- a/web/posts/plasmapy-v01-release.rst
+++ b/web/posts/plasmapy-v01-release.rst
@@ -1,12 +1,12 @@
 .. title: PlasmaPy v0.1 release!
 .. slug: plasmapy-v01-release
 .. date: 2018-04-30 05:27:00 UTC+02:00
-.. author: Dominik Stańczak
-.. tags: plasmapy, release, mathjax
+.. tags: plasmapy, release
 .. category: release
-.. link: 
 .. description: PlasmaPy v0.1 released
 .. type: text
+.. author: Dominik Stańczak
+.. has_math: yes
 
    I address you tonight not as a programmer of Python, not as a maintainer of a
    repository, but as a citizen of open source.


### PR DESCRIPTION
The purpose of this pull request is to make a landing page for the website, akin to [Astropy's landing page](https://www.astropy.org/).  Thus far I moved the blog posts to `news/`, changed the order of the tabs, and created `web/pages/index.md` for the new landing page.  We still need to discuss what would go in there.  

Closes #30.  Closes #28.