### PR TITLE
Update 1st PlasmaPy Workshop page with Cancellation Note

### DIFF
--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -5,7 +5,6 @@
     margin-bottom: 25px;
 }
 
-
 .main-text-block {
     margin-top: 25px;
     margin-bottom: 25px;
@@ -16,6 +15,26 @@
     text-align: center;
     margin: auto;
 }
+
+.plasmapy-note {
+    background-color: #e6fafa;
+    padding: 12px;
+    line-height: 24px;
+    margin-bottom: 24px;
+}
+
+.plasmapy-note-title {
+    background: #58a8a8;
+    font-weight: bold;
+    display: block;
+    color: #fff;
+    margin: -12px;
+    padding: 6px 12px;
+    margin-bottom: 12px;
+    font-family: inherit;
+}
+
+/* .plasmapy-note-title:before{content: "⚠"}
 
 /* Tables */
 table {

--- a/web/pages/meetings/1st_workshop_2020_at_bryn_mawr/index.md
+++ b/web/pages/meetings/1st_workshop_2020_at_bryn_mawr/index.md
@@ -6,6 +6,32 @@ hidetitle: True
 #### April 20-22, 2020
 #### Bryn Mawr College, Pennsylvania
 <br/>
+
+<div class="plasmapy-note">
+    <p class="plasmapy-note-title">
+        !! -- Workshop Cancelled
+    </p>
+    <p>
+        Due to the rapid development of COVID-19 (coronavirus) and out of an abundance
+        of caution, the PlasmaPy workshop organizers have decided to cancel PlasmaPy's 
+        first workshop.
+    </p>
+    <p>
+        We originally intended to web-cast portions of the workshop, but, with no 
+        in-person attendees, we feel this format would lead to a poor transmission of 
+        ideas between PlasmaPy and its community.  At this time, it is crucial that 
+        PlasmaPy fosters a strong community interaction to not only to convey its 
+        goals and ambitions, but to receive vital feed back from our community.  
+        <strong>Thus, we have decided to replace this workshop with a webinar 
+        series that will be given over the coming months.</strong>  As more information 
+        on the series becomes available we will update the community.
+    </p>
+    <p>
+        Thank you for your continued support,<br>
+        The PlasmaPy Workshop Organizers
+    </p>
+</div>
+
 [Overview](#Overview)<br/>
 [Agenda](#Agenda)<br/>
 [Registration](https://docs.google.com/forms/d/e/1FAIpQLSemaDDWHHq2li5B5W3vyYlnGjWEXGAD3Z3u1jSEG7vhpG22Dg/viewform?usp=sf_link)<br/>

--- a/web/pages/meetings/1st_workshop_2020_at_bryn_mawr/index.md
+++ b/web/pages/meetings/1st_workshop_2020_at_bryn_mawr/index.md
@@ -17,13 +17,13 @@ hidetitle: True
         first workshop.
     </p>
     <p>
-        We originally intended to web-cast portions of the workshop, but, with no 
-        in-person attendees, we feel this format would lead to a poor transmission of 
+        We originally intended to web-cast portions of the workshop, but with no 
+        in-person attendees we feel this format would lead to a poor transmission of 
         ideas between PlasmaPy and its community.  At this time, it is crucial that 
         PlasmaPy fosters a strong community interaction to not only to convey its 
         goals and ambitions, but to receive vital feed back from our community.  
-        <strong>Thus, we have decided to replace this workshop with a webinar 
-        series that will be given over the coming months.</strong>  As more information 
+        <strong>Thus, we have decided to replace this workshop with a series of webinars
+        and discussions to be held over the coming months.</strong>  As more information 
         on the series becomes available we will update the community.
     </p>
     <p>


### PR DESCRIPTION
Update the 1st PlasmaPy Workshop meeting page to indicate the meeting has been cancelled and that we intend to replace the workshop with a webinar series.