### PR TITLE
Fix broken/miss-directed documentation links

### DIFF
--- a/web/pages/contribute.md
+++ b/web/pages/contribute.md
@@ -64,7 +64,7 @@ a great idea for something to include in the package, start hacking away on
 that! However, please announce your intent first in the relevant issue (or make
 one if necessary) to make sure there is no work duplication.
 
-You can find most of what you should know in the [Contributing Guide](http://docs.plasmapy.org/en/master/development/index.html).
+You can find most of what you should know in the [Contributing Guide](http://docs.plasmapy.org/en/latest/development/index.html).
 
 Please note that PlasmaPy has a [Code of Conduct](/conduct).
 

--- a/web/pages/vision.md
+++ b/web/pages/vision.md
@@ -177,7 +177,7 @@ code](https://www.python.org/dev/peps/pep-0008/) and the established
 coding style within PlasmaPy.  New code should be submitted with
 documentation and tests.  Documentation should be written primarily in
 docstrings and follow the [numpydoc documentation style
-guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).
+guide](https://numpydoc.readthedocs.io/en/latest/format.html).
 Every new module, class and function should have an appropriate
 docstring.  The documentation should describe the interface and the
 purpose for the method, but generally not the implementation.  The

--- a/web/posts/plasmapy-v01-release.rst
+++ b/web/posts/plasmapy-v01-release.rst
@@ -13,7 +13,7 @@
 
    We are faced with the very newest of releases.
 
-   GitHub calls this one `PlasmaPy v0.1.0 <http://plasmapy.readthedocs.io/en/master/about/release_notes.html#version-0-1-0>`_, the first of the alphas.
+   GitHub calls this one `PlasmaPy v0.1.0 <http://docs.plasmapy.org/en/v0.1/about/release_notes.html#version-0-1-0>`_, the first of the alphas.
 
    And yet, for the first time in the history of this project our team has the
    technology to prevent its own procrastination.
@@ -34,11 +34,11 @@
    through `all of our ~2000 commits <https://github.com/PlasmaPy/PlasmaPy/commits/master>`_,
    there is one thing that has nourished our souls, and pushed us to complete
    this release, and that is our `pretty plots
-   <http://docs.plasmapy.org/en/master/auto_examples/index.html>`_. Oh, and the
+   <http://docs.plasmapy.org/en/latest/auto_examples/index.html>`_. Oh, and the
    possibility to 
-   `apply <http://docs.plasmapy.org/en/en/master/atomic/decorators.html#passing-particle-instances-to-functions-and-methods>`_
-   `more <http://docs.plasmapy.org/en/master/api/plasmapy.utils.checks.check_relativistic.html#plasmapy.utils.checks.check_relativistic>`_
-   `decorators <http://docs.plasmapy.org/en/master/api/plasmapy.utils.checks.check_quantity.html#plasmapy.utils.checks.check_quantity>`_.
+   `apply <http://docs.plasmapy.org/en/v0.1/atomic/decorators.html#passing-particle-instances-to-functions-and-methods>`_
+   `more <http://docs.plasmapy.org/en/v0.1/api/plasmapy.utils.checks.check_relativistic.html#plasmapy.utils.checks.check_relativistic>`_
+   `decorators <http://docs.plasmapy.org/en/v0.1/api/plasmapy.utils.checks.check_quantity.html#plasmapy.utils.checks.check_quantity>`_.
 
    The dreams of the entire PlasmaPy community are focused tonight on these `31
    brave committers <https://github.com/PlasmaPy/PlasmaPy/graphs/contributors>`_,
@@ -47,7 +47,7 @@
    And may we all, plasma enthusiasts the world over, see this release through.
 
    `Thermal speed
-   <http://docs.plasmapy.org/en/master/api/plasmapy.physics.parameters.thermal_speed.html#plasmapy.physics.parameters.thermal_speed>`_,
+   <http://docs.plasmapy.org/en/v0.1/api/plasmapy.physics.parameters.thermal_speed.html#plasmapy.physics.parameters.thermal_speed>`_,
    and a :math:`\sqrt{2}` to you,
   
    ~PlasmaPy

--- a/web/posts/plasmapy-v011-bugfix-release.rst
+++ b/web/posts/plasmapy-v011-bugfix-release.rst
@@ -9,7 +9,7 @@
 
 We have just released PlasmaPy v0.1.1, our first bugfix release which attempts to correct many of the flaws in our code we only noticed while releasing v0.1!
 
-Take a look at the `release notes <http://docs.plasmapy.org/en/stable/about/change_log.html#version-0-1-1>`_ to see what's changed.
+Take a look at the `release notes <http://docs.plasmapy.org/en/latest/whatsnew/0.1.1.html>`_ to see what's changed.
 
 As usual (although this is likely the first time you have reason to run this command), you should now be able to update via `pip install --upgrade plasmapy`.
 

--- a/web/posts/plasmapy-v020-release.rst
+++ b/web/posts/plasmapy-v020-release.rst
@@ -12,6 +12,6 @@ A few days ago the long overdue PlasmaPy release v0.2.0 `hit PyPI <https://pypi.
 
 If you'd rather use `conda <https://docs.conda.io/en/latest/>`_, though, you now have the option, and that is why we delayed the announcement: we now have `our very own conda-forge feedstock <https://github.com/conda-forge/plasmapy-feedstock>`_ and you can install PlasmaPy using `conda install -c conda-forge plasmapy`.
 
-Please refer to the `release notes <http://docs.plasmapy.org/en/stable/about/release_notes.html#version-0-2-0>`_ to see what's changed.
+Please refer to the `release notes <http://docs.plasmapy.org/en/latest/whatsnew/0.2.0.html>`_ to see what's changed.
 
 Happy coding, everyone!


### PR DESCRIPTION
This PR repairs a hand full of links that are either broken or miss-directed (e.g. going to the `master` version of RTDs vs the `latest` version).

Links in the PlasmaPy v0.1.0 post are now directed to the `v0.1` branch of RTDs.