### PR TITLE
Add a weekly meetings page

### DIFF
--- a/web/pages/meetings/index.md
+++ b/web/pages/meetings/index.md
@@ -5,7 +5,14 @@ author: Erik T. Everson
 
 ----
 
-#### [2020 April:  1st PlasmaPy Workshop](1st_workshop_2020_at_bryn_mawr)
+#### [Weekly Community Meeting](./weekly)
+Every Tuesday at 18:00 UTC
+
+# Past Meetings
+
+----
+
+#### [2020 April:  1st PlasmaPy Workshop [CANCELLED]](1st_workshop_2020_at_bryn_mawr)
 April 20-22, 2020
 
 PlasmaPy's first workshop, which is set up as a 3 day meeting for PlasmaPy developers and 
@@ -13,5 +20,3 @@ the PlasmaPy community. The first day (4/20) is designated for the PlasmaPy Team
 code development and project direction.  The remaining two days (4/21-4/22) are designed 
 for community interaction, informing the community of PlasmaPy's goals and features, as 
 well as, getting vital feedback from the community.
-
-[//]: # (# Past Meetings)

--- a/web/pages/meetings/index.md
+++ b/web/pages/meetings/index.md
@@ -5,10 +5,11 @@ author: Erik T. Everson
 
 ----
 
-#### [Weekly Community Meeting](./weekly)
-Every Tuesday at 18:00 UTC
+#### [Weekly Community Meeting](./weekly): Every Tuesday at 18:00 UTC
 
-# Past Meetings
+<br/>
+
+### Past Meetings
 
 ----
 

--- a/web/pages/meetings/weekly.md
+++ b/web/pages/meetings/weekly.md
@@ -19,8 +19,8 @@ Calendar:
 ### Overview
 
 Every Tuesday PlasmaPy hosts its weekly online community meeting to cover the various 
-ongoing topics and development, with some occasional bonus puns from Nick Murphy.
+ongoing development topics, with some occasional bonus puns from Nick Murphy.
 This call is hosted on [Jitsi] with the [minutes and agenda] available on Google Drive.
 The schedule is also published on our [calendar][google calendar].  Each meeting 
-is generally announced on our [Matrix chat][chat], with any last minute changes 
-also being on the chat.
+is announced on our [Matrix chat][chat] about an hour before the start, with any last 
+minute changes also being announced there.

--- a/web/pages/meetings/weekly.md
+++ b/web/pages/meetings/weekly.md
@@ -1,0 +1,26 @@
+title: Weekly PlasmaPy Community Meeting
+author: Erik T. Everson
+hidetitle: True
+
+[Jitsi]: https://meet.jit.si/plasmapy
+[minutes and agenda]: https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing
+[google calendar]: https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+[chat]: https://riot.im/app/#/room/#plasmapy:openastronomy.org
+
+# Weekly PlasmaPy Community Meeting
+#### Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT
+<br/>
+
+Where: [on Jitsi][Jitsi] <br/>
+Time: Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT
+Minutes & Agenda: 
+Calendar: 
+
+### Overview
+
+Every Tuesday PlasmaPy hosts its weekly online community meeting to cover the various 
+ongoing topics and development, with some occasional bonus puns from Nick Murphy.
+This call is hosted on [Jitsi] with the [minutes and agenda] available on Google Drive.
+The schedule is also published on our [calendar][google calendar].  Each meeting 
+is generally announced on our [Matrix chat][chat], with any last minute changes 
+also being on the chat.

--- a/web/pages/meetings/weekly.md
+++ b/web/pages/meetings/weekly.md
@@ -4,7 +4,7 @@ hidetitle: True
 
 [Jitsi]: https://meet.jit.si/plasmapy
 [minutes and agenda]: https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing
-[google calendar]: https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam00ZTlrMDd2cmw5bWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+[google calendar]: https://calendar.google.com/calendar/embed?src=o5lovdqm3illjm4e9k07vrl9mg%40group.calendar.google.com
 [chat]: https://riot.im/app/#/room/#plasmapy:openastronomy.org
 
 # Weekly PlasmaPy Community Meeting

--- a/web/pages/meetings/weekly.md
+++ b/web/pages/meetings/weekly.md
@@ -11,10 +11,11 @@ hidetitle: True
 #### Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT
 <br/>
 
-Where: [on Jitsi][Jitsi] <br/>
-Time: Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT
-Minutes & Agenda: 
-Calendar: 
+**Where:** [on Jitsi][Jitsi] <br/>
+**Time:** Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT <br/>
+**Minutes & Agenda:** [on Google Drive][minutes and agenda] <br/>
+**Calendar:** [on Google Calendar][google calendar] <br/>
+<br/><br/>
 
 ### Overview
 


### PR DESCRIPTION
Add a page for PlasmaPy's weekly meetings with all the appropriate info...

* jitsi link
* time
* calendar
* minutes and agenda
* matrix chat
* brief summary