### PR TITLE
Add Initial YouTube Content

### DIFF
--- a/web/conf.py
+++ b/web/conf.py
@@ -38,6 +38,7 @@ TELECON_CALENDAR = "https://calendar.google.com/calendar?cid=bzVsb3ZkcW0zaWxsam0
 TELECON_LINK = "https://jitsi.riot.im/plasmapy"
 TELECON_NOTES = "https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing"
 TWITTER = "https://twitter.com/plasmapy"
+YOUTUBE_CHANNEL = "https://www.youtube.com/channel/UCSH6qzslhqIZKTAJmHPxIxw"
 
 # Nikola is multilingual!
 #
@@ -156,6 +157,7 @@ NAVIGATION_LINKS = {
                 ("/about", "About PlasmaPy"),
                 ("/news", "News"),
                 (PROJECT_REPOSITORY, "GitHub Repository"),
+                (YOUTUBE_CHANNEL, "YouTube Channel"),
                 ("/acknowledging", "Acknowledging"),
                 ("/conduct", "Code of Conduct"),
             ),

--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -149,3 +149,21 @@ a.feature-link {
     color: inherit;
     text-decoration: inherit;
 }
+
+/* Graphic for Landing Page YouTube video */
+.aspect-ratio-80pc {
+    position: relative;
+    display: block;
+    text-align: center;
+    padding-bottom: 45.00%; /* to maintain 16:9 aspect ratio */
+    width: 80%;
+    margin: 0 10%;
+}
+
+.aspect-ratio-80pc iframe {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+}

--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -79,7 +79,7 @@ table tr th :last-child, table tr td :last-child {
 /* Float three columns side by side */
 .feature-column {
     float: left;
-    width: 33%;
+    width: 33.33%;
     padding: 0 5px;
 }
 

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -39,6 +39,17 @@ hidetitle: True
 
 <br/>
 
+<div class="aspect-ratio-80pc">
+    <iframe src="https://www.youtube-nocookie.com/embed/E8RwQF5wcXM"
+            style="border: 1px solid black"
+            frameborder="0" 
+            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen>
+    </iframe>
+</div>
+
+<br/>
+
 The goal of the PlasmaPy Project is to foster the creation of an open source [Python](https://www.python.org/) ecosystem for plasma research and education.  The PlasmaPy package contains core functionality for this software ecosystem, while affiliated packages will contain more specialized functionality.
 
 ## Install PlasmaPy


### PR DESCRIPTION
This PR adds links to our new YouTube Channel and 1st YouTube video.

1. A link to our YouTube channel is placed in the "About" top-menu.
1. Custom CSS styles created to place a YouTube video on the landing page, centered and at 80% width.
1. Our inaugural YouTube video is embedded on our landing page.
1. I tweaked the feature card widths to be 33.33% page width, vs 33%.  The difference was visually noticeable with the YouTube video below it.