### PR TITLE
Add 2020 PlasmaPy Survey to our landing page

### DIFF
--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -16,26 +16,6 @@
     margin: auto;
 }
 
-.plasmapy-note {
-    background-color: #e6fafa;
-    padding: 12px;
-    line-height: 24px;
-    margin-bottom: 24px;
-}
-
-.plasmapy-note-title {
-    background: #58a8a8;
-    font-weight: bold;
-    display: block;
-    color: #fff;
-    margin: -12px;
-    padding: 6px 12px;
-    margin-bottom: 12px;
-    font-family: inherit;
-}
-
-/* .plasmapy-note-title:before{content: "⚠"}
-
 /* Tables */
 table {
     padding: 0;
@@ -69,9 +49,32 @@ table tr th :last-child, table tr td :last-child {
     margin-bottom: 0;
 }
 
-/************************************/
-/*   Feature Cards for Front Page   */
-/************************************/
+/**********************************************************************
+ *  Admonitions
+ **********************************************************************/
+.plasmapy-note {
+    background-color: #e6fafa;
+    padding: 12px;
+    line-height: 24px;
+    margin-bottom: 24px;
+}
+
+.plasmapy-note-title {
+    background: #58a8a8;
+    font-weight: bold;
+    display: block;
+    color: #fff;
+    margin: -12px;
+    padding: 6px 12px;
+    margin-bottom: 12px;
+    font-family: inherit;
+}
+
+/* .plasmapy-note-title:before{content: "⚠"}
+
+/**********************************************************************
+ *   Feature Cards for Front Page
+ **********************************************************************/
 * {
     box-sizing: border-box;
 }
@@ -149,6 +152,10 @@ a.feature-link {
     color: inherit;
     text-decoration: inherit;
 }
+
+/**********************************************************************
+ *   For main page YouTube video
+ **********************************************************************/
 
 /* Graphic for Landing Page YouTube video */
 .aspect-ratio-80pc {

--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -138,13 +138,15 @@ table tr th :last-child, table tr td :last-child {
     border-color: #017BFF
 }
 
-.feature-card-text {
+/* Center (vertical & horizontal) div withing feature-card */
+.feature-card div {
     position: absolute;
-    width: inherit;
-    text-align: center;
+    width: 100%;
+    padding: 5%;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    text-align: center;
 }
 
 /* Hyperlink without decoration */

--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -134,7 +134,7 @@ table tr th :last-child, table tr td :last-child {
 }
 
 .feature-card:hover {
-    box-shadow: rgba(142, 176, 202, 0.5);
+    box-shadow: 0 4px 8px 0 rgba(142, 176, 202, 0.5);
     border-color: #017BFF
 }
 

--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -133,6 +133,16 @@ table tr th :last-child, table tr td :last-child {
     background-size: cover;
 }
 
+.feature-card-banner {
+    height: 36px;
+    background-image: none;
+    background-color: rgb(255, 237, 204);
+    box-shadow: none;
+    border-color: rgb(240, 179, 126);
+    border-width: 1px;
+    padding: 0 16px;
+}
+
 .feature-card:hover {
     box-shadow: 0 4px 8px 0 rgba(142, 176, 202, 0.5);
     border-color: #017BFF

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -1,6 +1,20 @@
 title: The PlasmaPy Project
 hidetitle: True
 
+<!-- Survey Card -->
+<div class="feature-row" style="margin: 24px 0">
+    <div class="feature-column" style="width: 100%; padding: 0 10%">
+        <a class="feature-link" href="https://docs.google.com/forms/d/e/1FAIpQLSeug7Wg1wWZdO10qV1X6dsOq1hn7kq3x8EXoDDjNYZ74ncuug/viewform">
+        <div class="feature-card feature-card-banner">
+            <div>
+                Please help us improve PlasmaPy and inform our development by 
+                taking the <b>2020 PlasmaPy Survey</b>.
+            </div>
+        </div>
+        </a>
+    </div>
+</div>
+
 <!-- Feature Cards -->
 <div class="feature-row">
     <!-- Feature 1 -->
@@ -47,19 +61,7 @@ hidetitle: True
     </div>
 </div>
 
-<!-- Survey Card -->
-<div class="feature-row" style="margin: 24px 0">
-    <div class="feature-column" style="width: 100%; padding: 0 10%">
-        <a class="feature-link" href="https://docs.google.com/forms/d/e/1FAIpQLSeug7Wg1wWZdO10qV1X6dsOq1hn7kq3x8EXoDDjNYZ74ncuug/viewform">
-        <div class="feature-card feature-card-banner">
-            <div>
-                Please help us improve PlasmaPy and inform our development by 
-                taking the <b>2020 PlasmaPy Survey</b>.
-            </div>
-        </div>
-        </a>
-    </div>
-</div>
+<br>
 
 <!-- YouTube Video-->
 <div class="aspect-ratio-80pc">

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -49,6 +49,7 @@ hidetitle: True
 
 <br/>
 
+<!-- YouTube Video-->
 <div class="aspect-ratio-80pc">
     <iframe src="https://www.youtube-nocookie.com/embed/E8RwQF5wcXM"
             style="border: 1px solid black"

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -47,7 +47,19 @@ hidetitle: True
     </div>
 </div>
 
-<br/>
+<!-- Survey Card -->
+<div class="feature-row" style="margin: 24px 0">
+    <div class="feature-column" style="width: 100%; padding: 0 10%">
+        <a class="feature-link" href="https://docs.google.com/forms/d/e/1FAIpQLSeug7Wg1wWZdO10qV1X6dsOq1hn7kq3x8EXoDDjNYZ74ncuug/viewform">
+        <div class="feature-card feature-card-banner">
+            <div>
+                Please help us improve PlasmaPy and inform our development by 
+                taking the <b>2020 PlasmaPy Survey</b>.
+            </div>
+        </div>
+        </a>
+    </div>
+</div>
 
 <!-- YouTube Video-->
 <div class="aspect-ratio-80pc">

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -1,47 +1,48 @@
 title: The PlasmaPy Project
 hidetitle: True
 
+<!-- Feature Cards -->
 <div class="feature-row">
     <!-- Feature 1 -->
     <div class="feature-column">
         <a class="feature-link" href="https://docs.plasmapy.org/en/latest/notebooks/thomson.html">
-        <span class="feature-card" 
+        <div class="feature-card" 
               style="background-image: linear-gradient(rgba(249, 96, 96, 0.55),
                                        rgba(255, 255, 255, 0.7)), 
                                        url('/images/features/thomson_spectral_density.png')">
-            <span class="feature-card-text">
+            <div>
                 <h2>New Feature</h2>
                 <h3>Thomson Scattering</h3>
                 <h3>Spectral Density</h3>
-            </span>
-        </span>
+            </div>
+        </div>
         </a>
     </div>
     <!-- Feature 2 -->
     <div class="feature-column">
         <a class="feature-link" href="meetings/weekly">
-        <span class="feature-card">
-            <span class="feature-card-text">
+        <div class="feature-card">
+            <div>
                 <h1>Weekly Community Meeting</h1>
-                <p>Tuesday 18:00 UTC</p>
-            </span>
-        </span>
+                Tuesday 18:00 UTC
+            </div>
+        </div>
         </a>
     </div>
     <!-- Feature 3 -->
     <div class="feature-column">
         <a class="feature-link" href="https://riot.im/app/#/room/#plasmapy:openastronomy.org">
-        <span class="feature-card" 
+        <div class="feature-card" 
               style="background-image: linear-gradient(rgba(255, 255, 255, 0.5), 
                                        rgba(255, 255, 255, 0.5)), 
                                        none; 
                      background-color: #80cece">
-            <span class="feature-card-text">
+            <div>
                 <h1>Join</h1>
                 <h3>the</h3>
                 <h1>Chat</h1>
-            </span>
-        </span>
+            </div>
+        </div>
         </a>
     </div>
 </div>


### PR DESCRIPTION
This PR does...

1. Improves CSS style for `.feature-card` (looks the same as before but with less needed code).
1. Add  CSS style `.feature-card-banner` for banner like cards.  This is used for the survey link.
1. Add a link to the 2020 PlasmaPy Survey on our landing page.

This is what the banner looks like...

![image](https://user-images.githubusercontent.com/29869348/89474399-54dbfe00-d73a-11ea-8d60-3957d1109014.png)

This is what it looks like when you hover over the banner before clicking...

![image](https://user-images.githubusercontent.com/29869348/89474476-979dd600-d73a-11ea-90e7-0365b51d0df7.png)

