### PR TITLE
Follow up to PR #65 - update CSS for vertical sizing

### DIFF
--- a/web/files/assets/css/custom.css
+++ b/web/files/assets/css/custom.css
@@ -134,7 +134,8 @@ table tr th :last-child, table tr td :last-child {
 }
 
 .feature-card-banner {
-    height: 36px;
+    min-height: 36px;
+    height: auto;
     background-image: none;
     background-color: rgb(255, 237, 204);
     box-shadow: none;
@@ -157,6 +158,15 @@ table tr th :last-child, table tr td :last-child {
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
+}
+.feature-card-banner div {
+    position: relative;
+    width: 100%;
+    padding: 5px 5%;
+    text-align: center;
+    top: auto;
+    left: auto;
+    transform: none;
 }
 
 /* Hyperlink without decoration */


### PR DESCRIPTION
Update CSS so the height of the `.feature-card-banner` class will auto adjust to content.  This is needed for good visibility on  mobile platforms.  Before the text would overflow the `div` element.