### PR TITLE
Fix examples link

### DIFF
--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -93,7 +93,7 @@ conda install -c conda-forge plasmapy
 
 ## Learn PlasmaPy
 
-[PlasmaPy's documentation](http://docs.plasmapy.org/en/latest) describes how to use PlasmaPy and provides several [examples](http://docs.plasmapy.org/en/latest/auto_examples/index.html). 
+[PlasmaPy's documentation](http://docs.plasmapy.org/en/latest) describes how to use PlasmaPy and provides several [examples](https://docs.plasmapy.org/en/latest/examples.html). 
 
 ## Get Help
 


### PR DESCRIPTION
The link to the PlasmaPy examples page was broken. This PR updates the link to point to the correct page in the documentation.