### PR TITLE
Announce time for weekly "office" hours

### DIFF
--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -28,7 +28,7 @@ hidetitle: True
             <div>
                 <h2>PlasmaPy</h2>
                 <h2>"Office" Hours</h2>
-                <h3>Oct. 7 & 8 at 18:00 UTC</h3>
+                <h3>Thursdays at 18:00 UTC</h3>
             </div>
         </div>
         </a>

--- a/web/pages/meetings/office_hours.md
+++ b/web/pages/meetings/office_hours.md
@@ -3,19 +3,18 @@ author: Nick Murphy
 hidetitle: True
 
 [Zoom link]: https://harvard.zoom.us/j/91600794594?pwd=L09iTGtTRUN1RmpsVnNvU05LRnNwQT09
-[PlasmaPy's chat room]: https://app.element.io/#/room/#plasmapy:openastronomy.org
+[chat room]: https://app.element.io/#/room/#plasmapy:openastronomy.org
 
 # PlasmaPy "Office" Hours
 
-Do you have a question about PlasmaPy?
-Would you like to learn how to become active in the PlasmaPy project?
-Do you have an idea for a great new feature or want to start an affiliated package?
-If so, please join us for **informal PlasmaPy "office" hours** at the following times:
+Do you have a question about PlasmaPy?  Would you like to learn how to
+become active in the PlasmaPy project?  Do you have an idea for a great
+new feature or want to start an affiliated package?
 
- - Wednesday, October 7 from 2–3 pm EDT
- - Thursday, October 8 from 2–3 pm EDT
+If so, then **please join us for informal PlasmaPy "office" hours on
+Thursdays at 18 UTC (2 pm EDT / 11 am PDT)**.  We will meet using this 
+[Zoom link].  Any last minute changes will be announced in PlasmaPy's 
+[chat room].
 
-We will meet using this **[Zoom link]**.  Please check [PlasmaPy's chat room] 
-if you have trouble joining. 
-
-Please check back here later for announcements of future office hours. 
+The [chat room] can be used to reach PlasmaPy developers at other times,
+in particular if the time for "office" hours does not work for you.


### PR DESCRIPTION
In #72, we announced special weekly office hours on 2020 Oct 7 & 8.  This PR changes that page and the feature card to announce a weekly time for office hours (tentatively Thursdays at 2 pm EDT).

**This should be merged no earlier than 2020 Oct 8.**