### PR TITLE
Create Page for 62nd DPP Mini-Conf Follow-up Meetings

### DIFF
--- a/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
+++ b/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
@@ -1,0 +1,23 @@
+title: 62nd APS DPP - 11.04 Mini-Conference Followups
+author: Erik T. Everson
+hidetitle: True
+
+[Zoom link]: https://harvard.zoom.us/j/91600794594?pwd=L09iTGtTRUN1RmpsVnNvU05LRnNwQT09
+[chat room]: https://app.element.io/#/room/#plasmapy:openastronomy.org
+
+# 62nd APS DPP - 11.04 Mini-Conference | Post-Meeting Discussions
+### Growing an open-source software ecosystem for plasma science
+
+<div style="height: 12px"><!-- Adding vertical whitespace --></div>
+
+**Where:** On Zoom [link will be updated] <br/>
+**Day 1:** Tuesday, November 17th at 21:00 UTC / 16:00 ET / 13:00 PT <br/>
+**Day 2:** Thursday, November 19th at 19:00 UTC / 14:00 ET / 11:00 PT <br/>
+
+<div style="height: 12px"><!-- Adding vertical whitespace --></div>
+
+In order to capitalize on the incredible information shared in this year's
+mini-conference, we plan to host a couple **post-meeting discussions**.  Here
+we can continue the discussion on fostering the open-source community, bringing
+in more members to our projects, organizing inter-project efforts, improving
+package interoperability, etc.

--- a/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
+++ b/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
@@ -16,7 +16,7 @@ hidetitle: True
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
 In order to capitalize on the incredible information shared in this year's
-mini-conference, we plan to host a couple **post-meeting discussions**.  Here
+mini-conference, we plan to host two **post-meeting discussions**.  Here
 we can continue the discussion on fostering the open-source community, bringing
 in more members to our projects, organizing inter-project efforts, improving
 package interoperability, etc.

--- a/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
+++ b/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
@@ -3,14 +3,13 @@ author: Erik T. Everson
 hidetitle: True
 
 [Zoom link]: https://harvard.zoom.us/j/91600794594?pwd=L09iTGtTRUN1RmpsVnNvU05LRnNwQT09
-[chat room]: https://app.element.io/#/room/#plasmapy:openastronomy.org
 
 # 62nd APS DPP - 11.04 Mini-Conference | Post-Meeting Discussions
 ### Growing an open-source software ecosystem for plasma science
 
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
-**Where:** On Zoom [link will be updated] <br/>
+**Where:** [On Zoom][Zoom Link] <br/>
 **Day 1:** Tuesday, November 17th at 21:00 UTC / 16:00 ET / 13:00 PT <br/>
 **Day 2:** Thursday, November 19th at 19:00 UTC / 14:00 ET / 11:00 PT <br/>
 

--- a/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
+++ b/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
@@ -15,7 +15,8 @@ hidetitle: True
 
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
-In order to capitalize on the incredible information shared in this year's
+In order to capitalize on the opportunities afforded by bringing together the
+diversity of speakers and attendees and perspectives during this year's 
 mini-conference, we plan to host two **post-meeting discussions**.  Here
 we can continue the discussion on fostering the open-source community, bringing
 in more members to our projects, organizing inter-project efforts, improving

--- a/web/pages/meetings/index.md
+++ b/web/pages/meetings/index.md
@@ -5,17 +5,17 @@ author: Erik T. Everson
 
 ----
 
-#### [Weekly Community Meeting](./weekly): Every Tuesday at 18:00 UTC
+#### [Weekly Community Meeting](./weekly): Every Tuesday at 11:00 PT / 14:00 ET
+
+<div style="height: 12px"><!-- Adding vertical whitespace --></div>
+
+#### [PlasmaPy "Office" Hours](./office_hours): Every Thursday at 11:00 PT/ 14:00 ET
 
 <br/>
 
 ### Upcoming Meetings
 
 ----
-
-#### [PlasmaPy "Office" Hours](./office_hours): October 7 & 8 from 2–3 pm EDT
-
-<div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
 #### [62nd APS DPP - 11.04 Mini-Conference](https://engage.aps.org/dpp/meetings/annual-meeting/mini-conferences): Growing an open source software ecosystem for plasma science
 November 11 & 12, 2020

--- a/web/pages/meetings/index.md
+++ b/web/pages/meetings/index.md
@@ -20,6 +20,12 @@ author: Erik T. Everson
 #### [62nd APS DPP - 11.04 Mini-Conference](https://engage.aps.org/dpp/meetings/annual-meeting/mini-conferences): Growing an open source software ecosystem for plasma science
 November 11 & 12, 2020
 
+<div style="height: 12px"><!-- Adding vertical whitespace --></div>
+
+#### [62nd APS DPP - 11.04 Mini-Conference | Post-Meeting Discussions](./aps/62nd_dpp_mini_conf_followups)
+Day 1: November 17, 2020 at 21:00 UTC / 16:00 ET / 13:00 PT<br/>
+Day 2: November 19, 2020 at 19:00 UTC / 14:00 ET / 11:00 PT
+
 <br/>
 
 ### Past Meetings


### PR DESCRIPTION
1. Create a page for the follow-up meetings associated with the 62nd APS DPP Mini-Conference on open-source software.
1. Add the page to the main meetings page.
1. On the main meetings page, update the "Office" Hours time and move it to the weekly meetings section.