### PR TITLE
Update times to reflect time change (plus updating copyright date & funding info)

### DIFF
--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -108,4 +108,4 @@ Making [feature requests](https://github.com/PlasmaPy/PlasmaPy/issues/new?templa
 
 ## Acknowledgments
 
-Ongoing development of PlasmaPy is supported by the U.S. National Science Foundation and NASA, with many contributions from the broader plasma physics and open source communities.  Early development of PlasmaPy was supported by the U.S. Department of Energy, the Smithsonian Institution, and Google Summer of Code.
+Ongoing development of PlasmaPy is supported by the U.S. National Science Foundation, with many contributions from the broader plasma physics and open source communities.  Past development of PlasmaPy has been supported by the U.S. Department of Energy, the Smithsonian Institution, NASA, and Google Summer of Code.

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -28,7 +28,7 @@ hidetitle: True
             <div>
                 <h2>PlasmaPy</h2>
                 <h2>"Office" Hours</h2>
-                <h3>Thursdays at 18:00 UTC</h3>
+                <h3>Thursdays at 19 UTC</h3>
             </div>
         </div>
         </a>
@@ -39,7 +39,7 @@ hidetitle: True
         <div class="feature-card">
             <div>
                 <h1>Weekly Community Meeting</h1>
-                Tuesday 18:00 UTC
+                Tuesday 19 UTC
             </div>
         </div>
         </a>

--- a/web/pages/license.md
+++ b/web/pages/license.md
@@ -11,7 +11,7 @@ source code and code snippets, is licensed under a [Creative Commons
 Attribution 4.0 International (CC BY 4.0)
 license](https://creativecommons.org/licenses/by/4.0/).
 
-Copyright (c) 2017, PlasmaPy Developers.
+Copyright (c) 2017-2020, PlasmaPy Developers.
 
 ## BSD 3-clause license with patent grant
 

--- a/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
+++ b/web/pages/meetings/aps/62nd_dpp_mini_conf_followups.md
@@ -10,8 +10,8 @@ hidetitle: True
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
 **Where:** [On Zoom][Zoom Link] <br/>
-**Day 1:** Tuesday, November 17th at 21:00 UTC / 16:00 ET / 13:00 PT <br/>
-**Day 2:** Thursday, November 19th at 19:00 UTC / 14:00 ET / 11:00 PT <br/>
+**Day 1:** Tuesday, November 17th at 21 UTC / 4 pm EST / 1 pm PST <br/>
+**Day 2:** Thursday, November 19th at 19 UTC / 2 pm EST / 11 am PST <br/>
 
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 

--- a/web/pages/meetings/index.md
+++ b/web/pages/meetings/index.md
@@ -5,11 +5,11 @@ author: Erik T. Everson
 
 ----
 
-#### [Weekly Community Meeting](./weekly): Every Tuesday at 11:00 PT / 14:00 ET
+#### [Weekly Community Meeting](./weekly): Every Tuesday at 19 UTC / 11 am PST / 2 pm EST
 
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
-#### [PlasmaPy "Office" Hours](./office_hours): Every Thursday at 11:00 PT/ 14:00 ET
+#### [PlasmaPy "Office" Hours](./office_hours): Every Thursday at 19 UTC / 11 am PST/ 2 pm ET
 
 <br/>
 
@@ -23,8 +23,8 @@ November 11 & 12, 2020
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 
 #### [62nd APS DPP - 11.04 Mini-Conference | Post-Meeting Discussions](./aps/62nd_dpp_mini_conf_followups)
-Day 1: November 17, 2020 at 21:00 UTC / 16:00 ET / 13:00 PT<br/>
-Day 2: November 19, 2020 at 19:00 UTC / 14:00 ET / 11:00 PT
+Day 1: November 17, 2020 at 21 UTC / 4 pm EST / 1 pm PST<br/>
+Day 2: November 19, 2020 at 19 UTC / 2 pm EST / 11 am PST
 
 <br/>
 

--- a/web/pages/meetings/office_hours.md
+++ b/web/pages/meetings/office_hours.md
@@ -12,7 +12,7 @@ become active in the PlasmaPy project?  Do you have an idea for a great
 new feature or want to start an affiliated package?
 
 If so, then **please join us for informal PlasmaPy "office" hours on
-Thursdays at 18 UTC (2 pm EDT / 11 am PDT)**.  We will meet using this 
+Thursdays at 19 UTC (2 pm EST / 11 am PST)**.  We will meet using this 
 [Zoom link].  Any last minute changes will be announced in PlasmaPy's 
 [chat room].
 

--- a/web/pages/meetings/weekly.md
+++ b/web/pages/meetings/weekly.md
@@ -8,11 +8,11 @@ hidetitle: True
 [chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
 
 # Weekly PlasmaPy Community Meeting
-#### Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT
+#### Every Tuesday at 19 UTC / 2 pm EST / 11 am PST
 <br/>
 
 **Where:** [on Jitsi][Jitsi] <br/>
-**Time:** Every Tuesday at 18:00 UTC / 14:00 ET / 11:00 PT <br/>
+**Time:** Every Tuesday at 19 UTC / 2 pm ET / 11 am PST <br/>
 **Minutes & Agenda:** [on Google Drive][minutes and agenda] <br/>
 **Calendar:** [on Google Calendar][google calendar] <br/>
 <br/><br/>


### PR DESCRIPTION
This PR changes the meeting times from 18 UTC to 19 UTC for the weekly meeting and office hours due to the change from daylight savings time to standard time in the US.  The times remain at 2 pm ET.  I consistentified the formatting of times, and stopped using 24-hour time for ET and PT since it's less common (and because I often end up having off-by-two errors...).  

I'm still hoping that there's a Nikola plugin hiding somewhere out there that would be able to convert a time we provide to the reader's local time zone.  One can dream...