### PR TITLE
Add `plasmapy.org/chat` redirect

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -670,7 +670,7 @@ ATOM_FILENAME_BASE = "feed"
 # relative URL.
 #
 # If you don't need any of these, just set to []
-REDIRECTIONS = []
+REDIRECTIONS = [("chat/index.html", CHAT)]
 
 # Presets of commands to execute to deploy. Can be anything, for
 # example, you may use rsync:


### PR DESCRIPTION
I saw https://github.com/sunpy/sunpy.org/pull/265/files and thought, hey, pretty. Let's do that as well.

This will let us point people to `plasmapy.org/chat` instead of whatever the complicated element links. We can also always change the redirect on the website.