### PR TITLE
Add PyMethes to affiliated pkgs

### DIFF
--- a/data/affiliated_pkgs.json
+++ b/data/affiliated_pkgs.json
@@ -67,5 +67,28 @@
     },
     "status": "stable",
     "license": "<a href='https://form.omfit.io'>User Agreement</a>"
+  },
+  "PyMethes": {
+    "maintainer": {
+      "name": "Christian M. Franck",
+      "contact": "cfanck@ethz.ch"
+    },
+    "urls": {
+      "home": "https://gitlab.com/ethz_hvl/pymethes",
+      "repo": "https://gitlab.com/ethz_hvl/pymethes",
+      "image": null
+    },
+    "description": {
+      "short": "A Monte Carlo simulation of electron transport in low temperature plasmas.",
+      "long": "A Monte Carlo simulation of electron transport in low temperature plasmas."
+    },
+    "affiliated": false,
+    "keywords": ["plasma", "physics", "Python 3", "simulation", "low-temperature"],
+    "dates": {
+      "added": "2021 June 23",
+      "last_updated": "2021 June 23"
+    },
+    "status": "stable",
+    "license": "GPLv3"
   }
 }

--- a/files/assets/css/custom.css
+++ b/files/assets/css/custom.css
@@ -229,8 +229,7 @@ a.feature-link {
 }
 
 /* -- right side info block -- */
-/* Table setup */
-table.aff-pkg-info-block {
+div.aff-pkg-info-block {
     display: block;
     float: left;
     width: 80%;
@@ -239,65 +238,74 @@ table.aff-pkg-info-block {
 
     border: none;
 }
-table.aff-pkg-info-block tbody {
+/* Table setup */
+div.aff-pkg-info-block table {
+    table-layout: fixed;
+    float: left;
+    width: 100%;
+    height: inherit;
+
+    border: none;
+}
+div.aff-pkg-info-block table tbody {
     display: inherit;
     width: 100%;
     height: inherit;
 }
-table.aff-pkg-info-block tr {
+div.aff-pkg-info-block table tr {
     border: none;
 }
-table.aff-pkg-info-block tr td {
+div.aff-pkg-info-block table tr td {
     border: none;
     padding: 0 4px;
 }
-table.aff-pkg-info-block tr:nth-child(even) {
+div.aff-pkg-info-block table tr:nth-child(even) {
     background: none;
 }
 
 /* Top Row */
-table.aff-pkg-info-block tr.main {
+div.aff-pkg-info-block table tr.main {
     height: 42px;
     border-bottom: 2px solid black;
 }
-table.aff-pkg-info-block tr.main td {
+div.aff-pkg-info-block table tr.main td {
     height: 40px;
     padding-bottom: 2px;
     padding-top: 2px;
 }
-table.aff-pkg-info-block tr.main td.pkg-name {
+div.aff-pkg-info-block table tr.main td.pkg-name {
     text-align: left;
 }
-table.aff-pkg-info-block tr.main td.pkg-links {
+div.aff-pkg-info-block table tr.main td.pkg-links {
     width: 120px;
     text-align: right;
 }
 
 /* Description Row */
-table.aff-pkg-info-block tr.description {
+div.aff-pkg-info-block table tr.description {
     height: 102px;
 }
-table.aff-pkg-info-block tr.description td {
+div.aff-pkg-info-block table tr.description td {
     height: inherit;
     padding-top: 0;
     padding-bottom: 0;
 }
-table.aff-pkg-info-block tr.description td p {
+div.aff-pkg-info-block table tr.description td p {
     height: inherit;
     text-align: left;
     overflow-y: scroll;
 }
 
 /* License & Keyword Rows */
-table.aff-pkg-info-block tr.license, tr.keywords {
+div.aff-pkg-info-block table tr.license, tr.keywords {
     height: 28px;
 }
-table.aff-pkg-info-block tr.license td, tr.keywords td {
+div.aff-pkg-info-block table tr.license td, tr.keywords td {
     height: inherit;
     text-align: left;
     vertical-align: bottom;
 }
-table.aff-pkg-info-block tr.license td p, tr.keywords td p {
+div.aff-pkg-info-block table tr.license td p, tr.keywords td p {
     height: inherit;
     text-align: left;
     overflow-y: scroll;

--- a/shortcodes/build_affiliated_pkg_list.tmpl
+++ b/shortcodes/build_affiliated_pkg_list.tmpl
@@ -72,7 +72,7 @@
 
 <div class="affiliated-pkg-list">
     <%
-          pkg_names = sorted(list(global_data['affiliated_pkgs'].keys()))
+          pkg_names = sorted(list(global_data['affiliated_pkgs'].keys()), key=str.casefold)
           pkg_names.insert(0, pkg_names.pop(pkg_names.index("plasmapy")))
     %>
 

--- a/shortcodes/build_affiliated_pkg_list.tmpl
+++ b/shortcodes/build_affiliated_pkg_list.tmpl
@@ -28,6 +28,7 @@
 ##                 <span class="feature-card">${image_path}</span>
             </a>
         </div>
+        <div class="aff-pkg-info-block">
         <table class="aff-pkg-info-block">
             <tr class="main">
                 <td class="pkg-name">
@@ -67,6 +68,7 @@
                 </td>
             </tr>
         </table>
+        </div>
     </div>
 </%def>
 


### PR DESCRIPTION
This adds [PyMethes](https://gitlab.com/ethz_hvl/pymethes) to the affiliated pkgs page.

In addition, I've made some improvements to the build_affiliated_pkg_list.tmpl shortcode and CSS to improve display of single line long descriptions and to ignore case when sorting the pkg list.

The PyMethes render looks like....

![image](https://user-images.githubusercontent.com/29869348/123188692-52b58780-d451-11eb-9762-7f46fff95452.png)
