### PR TITLE
Update event details

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -12,7 +12,7 @@ become active in the PlasmaPy project?  Do you have an idea for a great
 new feature or want to start an affiliated package?
 
 If so, then **please join us for informal PlasmaPy "office" hours on
-Thursdays at 2 pm ET / 11 am PT**.  We will meet using this 
+Thursdays at 3 pm ET / 12 pm PT**.  We will meet using this 
 [Zoom link].  Any last minute changes will be announced in PlasmaPy's 
 [chat room].
 

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -2,7 +2,7 @@ title: Weekly PlasmaPy Community Meeting
 author: Erik T. Everson
 hidetitle: True
 
-[Jitsi]: https://meet.jit.si/plasmapy
+[Zoom]: https://zoom.us/j/91633383503?pwd=QWNkdHpWeFhrYW1vQy91ODNTVG5Ndz09
 [minutes and agenda]: https://drive.google.com/drive/folders/0ByPG8nie6fTPV1FQUEkzMTgtRTg?usp=sharing
 [google calendar]: https://calendar.google.com/calendar/embed?src=o5lovdqm3illjm4e9k07vrl9mg%40group.calendar.google.com
 [chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
@@ -10,7 +10,7 @@ hidetitle: True
 # Weekly PlasmaPy Community Meeting
 #### Tuesdays at 2 pm ET / 11 am PT
 
-**Where:** [on Jitsi][Jitsi] <br/>
+**Where:** [on Zoom][Zoom] <br/>
 **Time:** Every Tuesday at 2 pm ET / 11 am PT <br/>
 **Minutes & Agenda:** [on Google Drive][minutes and agenda] <br/>
 **Calendar:** [on Google Calendar][google calendar] <br/>
@@ -20,7 +20,7 @@ hidetitle: True
 
 On Tuesdays PlasmaPy hosts its weekly online community meeting to cover the various 
 ongoing development topics, with some occasional bonus puns from Nick Murphy.
-This call is hosted on [Jitsi] with the [minutes and agenda] available on Google Drive.
+This call is hosted on [Zoom] with the [minutes and agenda] available on Google Drive.
 The schedule is also published on our [calendar][google calendar].  Each meeting 
 is announced on our [Matrix chat][chat] about an hour before the start, with any last 
 minute changes also being announced there.


### PR DESCRIPTION
This pull request is intended to make a few updates:

 - Update the link to meetings to the Zoom link from the PlasmaPy account (since we've have some issues with sharing screens with Jitsi)
 - Update the office hours time to be an hour later
 - Update community meeting information (hackmd instead of Google Drive)

I'm primarily getting this started because I keep forgetting until ∼5 minutes before each event that we need to do this, and this time I managed to remember 14 minutes ahead of time.  😬 