### PR TITLE
Put dates without weekly meetings or office hours on website

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -8,13 +8,16 @@ hidetitle: True
 # PlasmaPy "Office" Hours
 
 Do you have a question about PlasmaPy?  Would you like to learn how to
-become active in the PlasmaPy project?  Do you have an idea for a great
-new feature or want to start an affiliated package?
+become active in the PlasmaPy project?  Do you have an idea for a
+great new feature or want to start an affiliated package?
 
 If so, then **please join us for informal PlasmaPy "office" hours on
-Thursdays at 3 pm ET / 12 pm PT** (please note the time change).  We
-will meet on [Zoom].  Any last minute changes will be
-discussed in PlasmaPy's [chat room].
+most Thursdays at 3 pm ET / 12 pm PT**.  We will meet on [Zoom].  Any
+last minute changes will be discussed in PlasmaPy's [chat room].
 
-The [chat room] can be used to reach PlasmaPy developers at other times,
-in particular if the time for "office" hours does not work for you.
+We do not expect to hold office hours on June 23, July 14, October 20,
+November 24, December 22, and December 29 in 2022.
+
+The [chat room] can be used to reach PlasmaPy developers at other
+times, in particular if the time for "office" hours does not work for
+you.

--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -23,6 +23,6 @@ We will usually not hold office hours on [federal holidays] in the US,
 during the [APS DPP meeting], and from approximately December 23 to
 January 3.
 
-The [chat room] can be used to reach PlasmaPy developers at other
-times, in particular if the time for "office" hours does not work for
+PlasmaPy developers can be reached at other times via the [Matrix
+chat], in particular if the time for "office" hours does not work for
 you.

--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -3,7 +3,8 @@ author: Nick Murphy
 hidetitle: True
 
 [Zoom]: https://zoom.us/j/91633383503?pwd=QWNkdHpWeFhrYW1vQy91ODNTVG5Ndz09
-[chat room]: https://app.element.io/#/room/#plasmapy:openastronomy.org
+[Matrix chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
+[calendar]: https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz=America%2FNew_York
 
 # PlasmaPy "Office" Hours
 
@@ -12,11 +13,13 @@ become active in the PlasmaPy project?  Do you have an idea for a
 great new feature or want to start an affiliated package?
 
 If so, then **please join us for informal PlasmaPy "office" hours on
-most Thursdays at 3 pm ET / 12 pm PT**.  We will meet on [Zoom].  Any
-last minute changes will be discussed in PlasmaPy's [chat room].
+most Thursdays at 3 pm ET / 12 pm PT**.  We will meet on [Zoom].  The
+schedule is published on our [calendar].  Any last minute changes will
+be posted on our [Matrix chat].
 
-We do not expect to hold office hours on June 23, July 14, October 20,
-November 24, December 22, and December 29 in 2022.
+We will usually not hold office hours on [federal holidays] in the US,
+during the [APS DPP meeting], and from approximately December 23 to
+January 3.
 
 The [chat room] can be used to reach PlasmaPy developers at other
 times, in particular if the time for "office" hours does not work for

--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -5,6 +5,8 @@ hidetitle: True
 [Zoom]: https://zoom.us/j/91633383503?pwd=QWNkdHpWeFhrYW1vQy91ODNTVG5Ndz09
 [Matrix chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
 [calendar]: https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz=America%2FNew_York
+[federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
+[APS DPP meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
 
 # PlasmaPy "Office" Hours
 

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -23,3 +23,6 @@ topics related to code development. This call is hosted on [Zoom] with
 agendas and minutes available on [HackMD]. The schedule is published on
 our [calendar]. Any last minute changes will be discussed on our
 [Matrix chat].
+
+We do not expect to hold our weekly meeting on July 12, July 26,
+October 18, and December 27 in 2022 or January 3 in 2023.

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -6,6 +6,8 @@ hidetitle: True
 [HackMD]: https://hackmd.io/team/plasmapy
 [calendar]: https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz=America%2FNew_York
 [Matrix chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
+[federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
+[APS DPP meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
 
 # Weekly PlasmaPy Community Meeting
 #### Tuesdays at 2 pm ET / 11 am PT
@@ -18,11 +20,12 @@ hidetitle: True
 
 ### Overview
 
-On Tuesdays, PlasmaPy hosts its weekly online community meeting to cover
-topics related to code development. This call is hosted on [Zoom] with
-agendas and minutes available on [HackMD]. The schedule is published on
-our [calendar]. Any last minute changes will be discussed on our
-[Matrix chat].
+PlasmaPy's weekly online community meeting is held on most Tuesdays at
+2 pm ET / 11 am PT.  This call is hosted on [Zoom] with agendas and
+minutes available on [HackMD].  The schedule is published on our
+[calendar].  Any last minute changes will be posted on our [Matrix
+chat].
 
-We do not expect to hold our weekly meeting on July 12, July 26,
-October 18, and December 27 in 2022 or January 3 in 2023.
+We will usually not hold these meetings on [federal holidays] in the
+US, during the [APS DPP meeting], and from approximately December 23
+to January 3.


### PR DESCRIPTION
This PR adds dates when we will not hold our weekly meeting or office hours.  Apart from holidays, the dates & reasons are:

 - June 23: simultaneous SULI tutorial
 - July 12 & 14: hack week
 - July 26: @namurphy at CSSI meeting (should we hold weekly meeting anyway?)
 - October 18 & 20: APS DPP meeting