### PR TITLE
Update seasonal community meeting & office hour cancellation dates

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -19,9 +19,9 @@ most Thursdays at 3 pm ET / 12 pm PT**.  We will meet on [Zoom].  The
 schedule is published on our [calendar].  Any last minute changes will
 be posted on our [Matrix chat].
 
-We will usually not hold office hours on [federal holidays] in the US,
-during the [APS DPP meeting], and from approximately December 23 to
-January 3.
+We will not hold office hours on [federal holidays] in the US, the
+last two Thursdays of December, the first Thursday in January, or
+during the [APS DPP meeting].
 
 PlasmaPy developers can be reached at other times via the [Matrix
 chat], in particular if the time for "office" hours does not work for

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -26,6 +26,6 @@ minutes available on [HackMD].  The schedule is published on our
 [calendar].  Any last minute changes will be posted on our [Matrix
 chat].
 
-We will usually not hold these meetings on [federal holidays] in the
-US, during the [APS DPP meeting], and from approximately December 23
-to January 3.
+We will usually not hold community meetings on [federal holidays] in
+the US, the last two Tuesdays of December, the first Tuesday of
+January, or during the [APS DPP meeting].


### PR DESCRIPTION
This PR expands the dates where office hours and the community meeting will not be held around the end of the year.  