### PR TITLE
Remove survey link from 2021

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -1,7 +1,7 @@
 title: The PlasmaPy Project
 hidetitle: True
 
-<!-- Survey Card -->
+<!-- Survey Card 
 
 <div class="feature-row" style="margin: 24px 0">
     <div class="feature-column" style="width: 100%; padding: 0 10%">
@@ -14,7 +14,7 @@ hidetitle: True
         </div>
         </a>
     </div>
-</div>
+</div> -->
 
 <!-- Feature Cards -->
 <div class="feature-row">


### PR DESCRIPTION
This PR removes the survey card that was at the top of the webpage, at least for now, since the date on it was from 2021.  I'd be happy for us to update it and add it back in, though.