### PR TITLE
Add safe directory for deployment GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Add safe directory to avoid error
       run: |
-	git config --global --add safe.directory /github/workspace
+        git config --global --add safe.directory /github/workspace
     - name: Build and Deploy Nikola
       uses: getnikola/nikola-action@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Add safe directory to avoid error
-      run |
-        git config --global --add safe.directory /__w/PlasmaPy/plasmapy.github.io
+      run: |
+	git config --global --add safe.directory /github/workspace
     - name: Build and Deploy Nikola
       uses: getnikola/nikola-action@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+    - name: Add safe directory to avoid error
+      run |
+        git config --global --add safe.directory /__w/PlasmaPy/plasmapy.github.io
     - name: Build and Deploy Nikola
       uses: getnikola/nikola-action@v4
       with:


### PR DESCRIPTION
I just started getting this error:

```
REPO: PlasmaPy/plasmapy.github.io
ACTOR: namurphy
==> Preparing...
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

This PR adds that command.