### PR TITLE
Add away dates for summer 2023 for meetings & office hours

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -19,6 +19,9 @@ most Thursdays at 3 pm ET / 12 pm PT**.  We will meet on [Zoom].  The
 schedule is published on our [calendar].  Any last minute changes will
 be posted on our [Matrix chat].
 
+In the summer of 2023, we will not hold office hours on June 8, 15, &
+29 or July 13 & 27.
+
 We will not hold office hours on [federal holidays] in the US, the
 last two Thursdays of December, the first Thursday in January, or
 during the [APS DPP meeting].

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -13,7 +13,7 @@ hidetitle: True
 #### Tuesdays at 2 pm ET / 11 am PT
 
 **Where:** [on Zoom][Zoom] <br/>
-**Time:** Every Tuesday at 2 pm ET / 11 am PT <br/>
+**Time:** Tuesdays at 2 pm ET / 11 am PT <br/>
 **Minutes & Agenda:** on [HackMD] <br/>
 **Calendar:** [on Google Calendar][calendar] <br/>
 <br/><br/>
@@ -26,6 +26,10 @@ minutes available on [HackMD].  The schedule is published on our
 [calendar].  Any last minute changes will be posted on our [Matrix
 chat].
 
+In the summer of 2023, we will not have community meetings on June 13
+& 27; July 4, 18, & 25; and August 15.
+
 We will usually not hold community meetings on [federal holidays] in
 the US, the last two Tuesdays of December, the first Tuesday of
 January, or during the [APS DPP meeting].
+


### PR DESCRIPTION
Because there are going to be a bunch of days this summer where we won't be having our weekly meeting or office hours, I figured I'd add them to the event pages.