### PR TITLE
Update times for community meetings and office hours

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -15,12 +15,12 @@ become active in the PlasmaPy project? Do you have an idea for a great
 new feature or want to start an affiliated package?
 
 If so, then **please join us for informal PlasmaPy office hours on
-most Thursdays from 3–3:45 pm ET (12–12:45 pm PT)**. We will meet on
+most Wednesdays from 1–2 pm ET (10–11 am PT)**. We will meet on
 [Zoom]. The schedule is published on our [calendar]. Any last minute
 changes will be posted on our [Matrix chat].
 
-In 2024, we will not hold office hours on May 23 & 30, June 6, August
-1 & 8, and October 10.
+In 2024, we will not hold office hours on June 19, July 31, October 9
+& 16, November 13 & 27, and December 25.
 
 We will not hold office hours on [federal holidays] in the US, the
 last two Thursdays of December, the first Thursday in January, or

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -10,10 +10,10 @@ hidetitle: True
 [APS DPP meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
 
 # Weekly PlasmaPy Community Meeting
-#### Tuesdays at 2 pm ET / 11 am PT
+#### Wednesdays at 12 pm ET / 9 am PT
 
 **Where:** [on Zoom][Zoom] <br/>
-**Time:** Tuesdays at 2 pm ET / 11 am PT <br/>
+**Time:** Wednesdays at 12 pm ET / 9 am PT <br/>
 **Minutes & Agenda:** on [HackMD] <br/>
 **Calendar:** [on Google Calendar][calendar] <br/>
 <br/><br/>
@@ -21,13 +21,13 @@ hidetitle: True
 ### Overview
 
 PlasmaPy's weekly online community meeting is held on most Tuesdays at
-2 pm ET / 11 am PT.  This call is hosted on [Zoom] with agendas and
+12 pm ET / 9 am PT.  This call is hosted on [Zoom] with agendas and
 minutes available on [HackMD].  The schedule is published on our
 [calendar].  Any last minute changes will be posted on our [Matrix
 chat].
 
-In 2024, we will not hold community meetings on April 16, May 22, or
-October 8.
+In 2024, we will not have community meetings on June 19, July 31,
+October 9 & 16, November 13 & 27, and December 25.
 
 We will usually not hold community meetings on [federal holidays] in
 the US, the last two Tuesdays of December, the first Tuesday of


### PR DESCRIPTION
This PR is to update PlasmaPy community meeting times and office hours. This shouldn't be merged yet since the updated meeting times haven't been decided on.

When merged, we'll have to:

 - [ ] Update times on `README.md` on the `main` branch of `PlasmaPy/PlasmaPy`
 - [ ] Post about this in the Matrix/Element chat

An alternative would be to consolidate the community meeting & office hours, since community meetings are also an opportunity for people to come by.