### PR TITLE
Cancel weekly meetings an office hours in December 2024 & January 2025

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -18,12 +18,9 @@ If so, then **please join us for informal PlasmaPy office hours on
 most Thursdays from 3–3:45 pm ET (12–12:45 pm PT)**. We will meet on
 [Zoom]. The schedule is published on our [calendar].
 
-**Note: We will not hold community meetings in December 2024 or
-January 2025 due to an extended holiday.**
-
-<!--
-In 2024, we will not hold office hours on October 17 or November 28.
--->
+**Note: We will not hold office hours on November 21 & 28 due to
+forthcoming proposal deadlines, or in December 2024 and January 2025
+due to an extended holiday.**
 
 We will not hold office hours on [federal holidays] in the US, the
 last two Thursdays of December, the first Thursday in January, or

--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -18,9 +18,9 @@ If so, then **please join us for informal PlasmaPy office hours on
 most Thursdays from 3–3:45 pm ET (12–12:45 pm PT)**. We will meet on
 [Zoom]. The schedule is published on our [calendar].
 
-**Note: We will not hold office hours on November 21 & 28 due to
-forthcoming proposal deadlines, or in December 2024 and January 2025
-due to an extended holiday.**
+**Note: We will not hold office hours on November 21 or 28 or in
+December 2024 due to proposal deadlines and an extended holiday. Our
+next office hours will be on January 7.**
 
 We will not hold office hours on [federal holidays] in the US, the
 last two Thursdays of December, the first Thursday in January, or

--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -18,7 +18,12 @@ If so, then **please join us for informal PlasmaPy office hours on
 most Thursdays from 3–3:45 pm ET (12–12:45 pm PT)**. We will meet on
 [Zoom]. The schedule is published on our [calendar].
 
+**Note: We will not hold community meetings in December 2024 or
+January 2025 due to an extended holiday.**
+
+<!--
 In 2024, we will not hold office hours on October 17 or November 28.
+-->
 
 We will not hold office hours on [federal holidays] in the US, the
 last two Thursdays of December, the first Thursday in January, or

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -24,8 +24,8 @@ PlasmaPy's weekly online community meeting is held on most Tuesdays at
 2 pm ET / 11 am PT.  This call is hosted on [Zoom].  The schedule is
 published on our [calendar].
 
-**Note: We will not hold community meetings in December 2024 or
-January 2025 due to an extended holiday.**
+**Note: We will not hold community meetings in December 2024 or due to
+an extended holiday.**
 
 <!--
 In 2024, we will not hold community meetings on October 15 and November 26.

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -24,8 +24,9 @@ PlasmaPy's weekly online community meeting is held on most Tuesdays at
 2 pm ET / 11 am PT.  This call is hosted on [Zoom].  The schedule is
 published on our [calendar].
 
-**Note: We will not hold community meetings in December 2024 or due to
-an extended holiday.**
+**Note: We will not hold community meetings on November 26 or in
+December 2024 due to proposal deadlines and an extended holiday. Our
+next community meeting will be on January 7, 2025.**
 
 <!--
 In 2024, we will not hold community meetings on October 15 and November 26.

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -21,11 +21,15 @@ hidetitle: True
 ### Overview
 
 PlasmaPy's weekly online community meeting is held on most Tuesdays at
-2 pm ET / 11 am PT.  This call is hosted on [Zoom] with agendas and
-minutes available on [HackMD].  The schedule is published on our
-[calendar].
+2 pm ET / 11 am PT.  This call is hosted on [Zoom].  The schedule is
+published on our [calendar].
 
+**Note: We will not hold community meetings in December 2024 or
+January 2025 due to an extended holiday.**
+
+<!--
 In 2024, we will not hold community meetings on October 15 and November 26.
+-->
 
 We will not hold community meetings on [federal holidays] in the US,
 the last two Tuesdays of December, the first Tuesday of January, or


### PR DESCRIPTION
Most of the people who have been hosting meetings and office hours will be taking an extended holiday or returning from Antarctica in the next ∼2 months, so I'm going to cancel meetings & office hours.

Since the current NSF CSSI award that supports PlasmaPy development will be ending in early to mid 2025, we may put office hours on hiatus for a while.  