### PR TITLE
Update office hour and meeting cancellations

### DIFF
--- a/pages/meetings/office_hours.md
+++ b/pages/meetings/office_hours.md
@@ -18,12 +18,8 @@ If so, then **please join us for informal PlasmaPy office hours on
 most Thursdays from 3–3:45 pm ET (12–12:45 pm PT)**. We will meet on
 [Zoom]. The schedule is published on our [calendar].
 
-**Note: We will not hold office hours on November 21 or 28 or in
-December 2024 due to proposal deadlines and an extended holiday. Our
-next office hours will be on January 7.**
-
 We will not hold office hours on [federal holidays] in the US, the
-last two Thursdays of December, the first Thursday in January, or
+last two Thursdays of December, the first two Thursdays in January, or
 during the [APS DPP meeting].
 
 PlasmaPy developers can be reached at other times via the [Matrix

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -24,14 +24,6 @@ PlasmaPy's weekly online community meeting is held on most Tuesdays at
 2 pm ET / 11 am PT.  This call is hosted on [Zoom].  The schedule is
 published on our [calendar].
 
-**Note: We will not hold community meetings on November 26 or in
-December 2024 due to proposal deadlines and an extended holiday. Our
-next community meeting will be on January 7, 2025.**
-
-<!--
-In 2024, we will not hold community meetings on October 15 and November 26.
--->
-
 We will not hold community meetings on [federal holidays] in the US,
 the last two Tuesdays of December, the first Tuesday of January, or
 during the [APS DPP meeting].


### PR DESCRIPTION
This PR removes some temporary text from the website which stated dates that we didn't hold office hours or our weekly meeting.