### PR TITLE
Adapt summer school page to use past tense

### DIFF
--- a/pages/meetings/summer-school-2024.md
+++ b/pages/meetings/summer-school-2024.md
@@ -6,24 +6,20 @@ hidetitle: True
 [PlasmaPy]: https://docs.plasmapy.org
 [**schedule**]: https://docs.google.com/spreadsheets/d/1avWQ2Lb1zc9v71E5oUrCVlY1UwFLWiD4U_vHdzQDFog/edit?usp=sharing
 [unconference]: https://en.wikipedia.org/wiki/Unconference
-[PlasmaPy Code of Conduct]: https://docs.plasmapy.org/en/latest/CODE_OF_CONDUCT.html
 
 # PlasmaPy Summer School 2024
 
-The PlasmaPy community is hosting its inaugural summer school at [Bryn
-Mawr College] in Bryn Mar, Pennsylvania, USA (about a 30 minute drive
-from central Philadelphia). After introducing how to use PlasmaPy, this
-workshop will help participants learn how to contribute to an open
-source software project.
-
-This summer school will fall under the [PlasmaPy Code of Conduct].
+The PlasmaPy community held its inaugural summer school at [Bryn Mawr
+College] in Bryn Mawr, Pennsylvania, USA. This workshop provided
+participants with an opportunity to learn how to use PlasmaPy and
+contribute to an open source software project.
 
 ## Schedule
 
 Please click here for the [**schedule**] for the PlasmaPy summer school,
-which is being held from Monday, July 29 to Thursday, August 1.
+which was held from Monday, July 29 to Thursday, August 1 in 2024.
 
-The summer school will cover the following topics:
+The summer school covered the following topics:
 
 - [PlasmaPy]'s origin story
 - Contributing to an open source project
@@ -36,59 +32,11 @@ The summer school will cover the following topics:
 - Testing software
 - Code contribution tips
 
-The schedule includes small group discussions for people at similar
+The schedule included small group discussions for people at similar
 career/educational stages, [unconference] sessions, and time for pair
 programming or contributing.
 
-## Logistics
-
-### Lodging
-
-[Wayne Hotel]: https://waynehotel.com/directions/
-
-All selected participants will be staying at the [Wayne Hotel] (139 East
-Lancaster Avenue, Wayne, PA 19087), which is about 15 minutes from Bryn
-Mawr College by car. Accommodations have already been arranged by the
-College; when you arrive, participants will only need to provide their
-name and that they are part of Bryn Mawr College's PlasmaPy school. You
-may also be asked to provide a credit or debit card for incidentals —
-the travel reimbursement will not include any charges to the room beyond
-the nightly housing rate and taxes.
-
-### Transportation
-
-Bus transportation has been arranged between the [Wayne Hotel] and the
-school location on Bryn Mawr's campus.
-
-**A Bryn Mawr bus will leave from the hotel at 8:15 am every morning of
-the workshop (Mon–Thurs) to take participants to campus and a return bus
-to the hotel will leave at 6:40pm after dinner.**
-
-If you miss the bus and need to take taxi or ride share transportation
-to the campus/hotel, note that this cannot be reimbursed. Only arrival
-and departure road transportation (i.e., to/from the airport) can be
-reimbursed.
-
-### Meals
-
-There is breakfast available at the Wayne Hotel but there will also be
-light continental breakfast and coffee provided before the beginning of
-each day's sessions. Lunches will be at the on-campus dining hall which
-is buffet style and typically can accommodate all dietary restrictions.
-Dinners will be provided at Bryn Mawr College's on campus restaurant,
-Wyndham House. Similarly a selection of menu items will be provided to
-accommodate dietary restrictions.
-
-## Applications
-
-The application process is now closed, having had 82 applicants for 25
-available spots. Thank you to everyone who applied!
-
-## Contact information
-
-If you have questions, please feel free to email <team@plasmapy.org>.
-
 ## Acknowledgments
 
-This summer school is being supported by NSF awards 1931388, 1931393,
+This summer school was supported by NSF awards 1931388, 1931393,
 1931429, and 1931435.


### PR DESCRIPTION
The PlasmaPy Summer School was held in the summer of 2024, so the logistics sections of the summer school pages are no longer needed.  This PR removes those sections and puts the page in the past tense.

> [!NOTE]
> If we are lucky enough to hold a summer school at Bryn Mawr in the future, we can look back into version control for the older versions of this page. Yay for version control!