### PR TITLE
Change meeting times to every other Monday at 1 pm ET

### DIFF
--- a/pages/meetings/index.md
+++ b/pages/meetings/index.md
@@ -1,11 +1,11 @@
 title: PlasmaPy Meetings
 author: Erik T. Everson
 
-### Weekly Meetings
+### Meetings
 
 ----
 
-#### [Weekly Community Meeting](./weekly): Most Thursdays at 11 am PT / 2 pm ET
+#### [Biweekly Community Meeting](./weekly): Every other Monday at 1 pm ET / 10 am PT
 
 <div style="height: 12px"><!-- Adding vertical whitespace --></div>
 

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -17,12 +17,12 @@ hidetitle: True
 
 ### Overview
 
-PlasmaPy's online community meetings are typically held on every 
+PlasmaPy's online community meetings are typically held on every
 other Monday at 1 pm ET / 10 am PT.
 This call is hosted on [Zoom].
 The schedule is published on our [calendar].
 
-Regularly scheduled meetings in 2025 will be held on October 6 & 20, 
+Regularly scheduled meetings in 2025 will be held on October 6 & 20,
 November 3, and December 16.
 
 We will not hold community meetings on [federal holidays] in the US,

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -1,30 +1,29 @@
-title: Weekly PlasmaPy Community Meeting
-author: Erik T. Everson
+title: PlasmaPy Community Meeting
+author: Nick Murphy
 hidetitle: True
 
 [Zoom]: https://zoom.us/j/91633383503?pwd=QWNkdHpWeFhrYW1vQy91ODNTVG5Ndz09
 [calendar]: https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz=America%2FNew_York
-[Matrix chat]: https://app.element.io/#/room/#plasmapy:openastronomy.org
 [federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
 [APS DPP meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
 
-# Weekly PlasmaPy Community Meeting
-#### Thursdays at 2 pm ET / 11 am PT
+# PlasmaPy Community Meeting
+#### Every other Monday at 1 pm ET / 10 am PT
 
 **Where:** [on Zoom][Zoom] <br/>
-**Time:** Thursdays at 2 pm ET / 11 am PT <br/>
-**Calendar:** [on Google Calendar][calendar] <br/>
+**Time:** Every other Monday at 1 pm ET / 10 am PT <br/>
+**Calendar:** [Google Calendar][calendar] <br/>
 <br/><br/>
 
 ### Overview
 
-PlasmaPy's weekly online community meeting is held on most Thursdays at
-2 pm ET / 11 am PT.  This call is hosted on [Zoom].  The schedule is
-published on our [calendar].
+PlasmaPy's online community meetings are typically held on every 
+other Monday at 1 pm ET / 10 am PT.
+This call is hosted on [Zoom].
+The schedule is published on our [calendar].
 
-We will not hold community meetings on August 14, 21, & 28; November
-20 & 27; or December 18 & 25 in 2025.
+Regularly scheduled meetings in 2025 will be held on October 6 & 20, 
+November 3, and December 16.
 
 We will not hold community meetings on [federal holidays] in the US,
-the last two Tuesdays of December, the first Tuesday of January, or
-during the [APS DPP meeting].
+between December 20 – Jan 3, or during the [APS DPP meeting].


### PR DESCRIPTION
Since the NSF CSSI award is ending imminently, we are changing the meeting times from weekly to fortnightly.  The next meeting will be on October 6.