### PR TITLE
Make calendar display user's local timezone

### DIFF
--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -23,11 +23,6 @@ Regularly scheduled meetings in 2026 are planned for January 26; February 9 & 23
 We will not hold community meetings on [federal holidays] in the US,
 between December 20 – Jan 3, or during the [APS DPP meeting].
 
-[aps dpp meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
-
-[federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
-[zoom]: https://smithsonian.zoom.us/j/81436771842?pwd=rvuXPS6Ze4uONv9vA9A3mzkSAqlben.1
-
 <script>
   const timezone =
     Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -39,3 +34,7 @@ between December 20 – Jan 3, or during the [APS DPP meeting].
   document.getElementById("calendar-link").href =
     calendarUrl;
 </script>
+
+[aps dpp meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
+[federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
+[zoom]: https://smithsonian.zoom.us/j/81436771842?pwd=rvuXPS6Ze4uONv9vA9A3mzkSAqlben.1

--- a/pages/meetings/weekly.md
+++ b/pages/meetings/weekly.md
@@ -8,7 +8,7 @@ hidetitle: True
 
 **Where:** [on Zoom][zoom] <br/>
 **Time:** Every other Monday at 1 pm ET / 10 am PT <br/>
-**Calendar:** [Google Calendar][calendar] <br/>
+**Calendar:** <a id="calendar-link" target="_blank">Google Calendar</a> <br/>
 <br/><br/>
 
 ### Overview
@@ -24,6 +24,18 @@ We will not hold community meetings on [federal holidays] in the US,
 between December 20 – Jan 3, or during the [APS DPP meeting].
 
 [aps dpp meeting]: https://engage.aps.org/dpp/meetings/annual-meeting
-[calendar]: https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz=America%2FNew_York
+
 [federal holidays]: https://www.opm.gov/policy-data-oversight/pay-leave/federal-holidays/#url=Overview
 [zoom]: https://smithsonian.zoom.us/j/81436771842?pwd=rvuXPS6Ze4uONv9vA9A3mzkSAqlben.1
+
+<script>
+  const timezone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const calendarUrl =
+    "https://calendar.google.com/calendar/embed?src=c_sqqq390s24jjfjp3q86pv41pi8%40group.calendar.google.com&ctz="
+    + encodeURIComponent(timezone);
+
+  document.getElementById("calendar-link").href =
+    calendarUrl;
+</script>


### PR DESCRIPTION

Removed hardcoded America/New York
Added browser time zone detection
Dynamically generated calendar link
Improved international usability